### PR TITLE
feat: prototype orgmode haustoria with WebDAV and SFTP transports

### DIFF
--- a/go/internal/echo/workspace_config_blobs/v2.go
+++ b/go/internal/echo/workspace_config_blobs/v2.go
@@ -15,6 +15,8 @@ type HaustoriaConfig struct {
 	Type      string                    `toml:"type"`
 	CalDAV    *CalDAVConfig             `toml:"caldav,omitempty"`
 	Calendars map[string]CalendarConfig `toml:"calendars,omitempty"`
+	Orgmode   *OrgmodeConfig            `toml:"orgmode,omitempty"`
+	Folders   map[string]FolderConfig   `toml:"folders,omitempty"`
 }
 
 type CalDAVConfig struct {
@@ -28,6 +30,110 @@ type CalendarConfig struct {
 	Type       string            `toml:"type"`
 	Tags       []string          `toml:"tags,omitempty"`
 	StatusTags map[string]string `toml:"status-tags,omitempty"`
+}
+
+// OrgmodeConfig holds orgmode haustoria connection parameters. Supports
+// WebDAV or SFTP as the file transport.
+type OrgmodeConfig struct {
+	Transport string          `toml:"transport"` // "webdav" or "sftp"
+	WebDAV    *OrgmodeWebDAV  `toml:"webdav,omitempty"`
+	SFTP      *OrgmodeSFTP    `toml:"sftp,omitempty"`
+}
+
+// OrgmodeWebDAV holds WebDAV connection parameters for orgmode sync.
+type OrgmodeWebDAV struct {
+	URL      string `toml:"url"`
+	Username string `toml:"username"`
+}
+
+// OrgmodeSFTP holds SFTP connection parameters for orgmode sync.
+type OrgmodeSFTP struct {
+	Host           string `toml:"host"`
+	Port           int    `toml:"port"`
+	User           string `toml:"user"`
+	PrivateKeyPath string `toml:"private-key-path"`
+}
+
+// FolderConfig maps a remote folder to a dodder type and optional tags.
+type FolderConfig struct {
+	Path string   `toml:"path"`
+	Type string   `toml:"type"`
+	Tags []string `toml:"tags,omitempty"`
+}
+
+// ResolveOrgmode merges TOML config values with environment variables for
+// orgmode haustoria. Env vars: ORGMODE_WEBDAV_URL, ORGMODE_WEBDAV_USERNAME,
+// ORGMODE_WEBDAV_PASSWORD, ORGMODE_SFTP_HOST, ORGMODE_SFTP_USER,
+// ORGMODE_SFTP_PASSWORD.
+func (orgmodeConfig OrgmodeConfig) ResolveOrgmode() (ResolvedOrgmodeConfig, error) {
+	resolved := ResolvedOrgmodeConfig{
+		Transport: orgmodeConfig.Transport,
+	}
+
+	switch orgmodeConfig.Transport {
+	case "webdav", "":
+		resolved.Transport = "webdav"
+
+		if orgmodeConfig.WebDAV != nil {
+			resolved.WebDAVURL = orgmodeConfig.WebDAV.URL
+			resolved.WebDAVUsername = orgmodeConfig.WebDAV.Username
+		}
+
+		if resolved.WebDAVURL == "" {
+			resolved.WebDAVURL = os.Getenv("ORGMODE_WEBDAV_URL")
+		}
+		if resolved.WebDAVUsername == "" {
+			resolved.WebDAVUsername = os.Getenv("ORGMODE_WEBDAV_USERNAME")
+		}
+
+		resolved.WebDAVPassword = os.Getenv("ORGMODE_WEBDAV_PASSWORD")
+
+		if resolved.WebDAVURL == "" {
+			return resolved, fmt.Errorf("orgmode WebDAV URL required: set [haustoria.orgmode.webdav] url or ORGMODE_WEBDAV_URL")
+		}
+
+	case "sftp":
+		if orgmodeConfig.SFTP != nil {
+			resolved.SFTPHost = orgmodeConfig.SFTP.Host
+			resolved.SFTPPort = orgmodeConfig.SFTP.Port
+			resolved.SFTPUser = orgmodeConfig.SFTP.User
+			resolved.SFTPPrivateKeyPath = orgmodeConfig.SFTP.PrivateKeyPath
+		}
+
+		if resolved.SFTPHost == "" {
+			resolved.SFTPHost = os.Getenv("ORGMODE_SFTP_HOST")
+		}
+		if resolved.SFTPUser == "" {
+			resolved.SFTPUser = os.Getenv("ORGMODE_SFTP_USER")
+		}
+
+		resolved.SFTPPassword = os.Getenv("ORGMODE_SFTP_PASSWORD")
+
+		if resolved.SFTPHost == "" {
+			return resolved, fmt.Errorf("orgmode SFTP host required: set [haustoria.orgmode.sftp] host or ORGMODE_SFTP_HOST")
+		}
+		if resolved.SFTPUser == "" {
+			return resolved, fmt.Errorf("orgmode SFTP user required: set [haustoria.orgmode.sftp] user or ORGMODE_SFTP_USER")
+		}
+
+	default:
+		return resolved, fmt.Errorf("unknown orgmode transport: %s (supported: webdav, sftp)", orgmodeConfig.Transport)
+	}
+
+	return resolved, nil
+}
+
+// ResolvedOrgmodeConfig holds fully resolved orgmode connection parameters.
+type ResolvedOrgmodeConfig struct {
+	Transport          string
+	WebDAVURL          string
+	WebDAVUsername     string
+	WebDAVPassword     string
+	SFTPHost           string
+	SFTPPort           int
+	SFTPUser           string
+	SFTPPassword       string
+	SFTPPrivateKeyPath string
 }
 
 // Resolve merges TOML config values with environment variables.

--- a/go/internal/echo/workspace_config_blobs/v2_tommy.go
+++ b/go/internal/echo/workspace_config_blobs/v2_tommy.go
@@ -121,6 +121,74 @@ func DecodeV2(input []byte) (*V2Document, error) {
 				}
 			}
 		}
+		if tableNode := d.cstDoc.FindTableInContainer(tableNode, "orgmode"); tableNode != nil {
+			d.consumed["haustoria.orgmode"] = true
+			orgmodeVal := &OrgmodeConfig{}
+			if v, err := document.GetFromContainer[string](d.cstDoc, tableNode, "transport"); err == nil {
+				orgmodeVal.Transport = v
+				d.consumed["haustoria.orgmode.transport"] = true
+			}
+			if webdavNode := d.cstDoc.FindTableInContainer(tableNode, "webdav"); webdavNode != nil {
+				d.consumed["haustoria.orgmode.webdav"] = true
+				webdavVal := &OrgmodeWebDAV{}
+				if v, err := document.GetFromContainer[string](d.cstDoc, webdavNode, "url"); err == nil {
+					webdavVal.URL = v
+					d.consumed["haustoria.orgmode.webdav.url"] = true
+				}
+				if v, err := document.GetFromContainer[string](d.cstDoc, webdavNode, "username"); err == nil {
+					webdavVal.Username = v
+					d.consumed["haustoria.orgmode.webdav.username"] = true
+				}
+				orgmodeVal.WebDAV = webdavVal
+			}
+			if sftpNode := d.cstDoc.FindTableInContainer(tableNode, "sftp"); sftpNode != nil {
+				d.consumed["haustoria.orgmode.sftp"] = true
+				sftpVal := &OrgmodeSFTP{}
+				if v, err := document.GetFromContainer[string](d.cstDoc, sftpNode, "host"); err == nil {
+					sftpVal.Host = v
+					d.consumed["haustoria.orgmode.sftp.host"] = true
+				}
+				if v, err := document.GetFromContainer[int](d.cstDoc, sftpNode, "port"); err == nil {
+					sftpVal.Port = v
+					d.consumed["haustoria.orgmode.sftp.port"] = true
+				}
+				if v, err := document.GetFromContainer[string](d.cstDoc, sftpNode, "user"); err == nil {
+					sftpVal.User = v
+					d.consumed["haustoria.orgmode.sftp.user"] = true
+				}
+				if v, err := document.GetFromContainer[string](d.cstDoc, sftpNode, "private-key-path"); err == nil {
+					sftpVal.PrivateKeyPath = v
+					d.consumed["haustoria.orgmode.sftp.private-key-path"] = true
+				}
+				orgmodeVal.SFTP = sftpVal
+			}
+			d.data.Haustoria.Orgmode = orgmodeVal
+		}
+		{
+			subTables := d.cstDoc.FindSubTablesInContainer(tableNode, "folders")
+			if len(subTables) > 0 {
+				d.consumed["haustoria.folders"] = true
+				d.data.Haustoria.Folders = make(map[string]FolderConfig)
+				for _, subTable := range subTables {
+					mapKey := document.SubTableKeyInContainer(subTable, tableNode, "folders")
+					d.consumed["haustoria.folders"+"."+mapKey] = true
+					var entry FolderConfig
+					if v, err := document.GetFromContainer[string](d.cstDoc, subTable, "path"); err == nil {
+						entry.Path = v
+						d.consumed["haustoria.folders.path"] = true
+					}
+					if v, err := document.GetFromContainer[string](d.cstDoc, subTable, "type"); err == nil {
+						entry.Type = v
+						d.consumed["haustoria.folders.type"] = true
+					}
+					if v, err := document.GetFromContainer[[]string](d.cstDoc, subTable, "tags"); err == nil {
+						entry.Tags = v
+						d.consumed["haustoria.folders.tags"] = true
+					}
+					d.data.Haustoria.Folders[mapKey] = entry
+				}
+			}
+		}
 	}
 
 	return d, nil
@@ -213,6 +281,70 @@ func (d *V2Document) Encode() ([]byte, error) {
 						if err := d.cstDoc.SetInContainer(tableNode, k, v); err != nil {
 							return nil, err
 						}
+					}
+				}
+			}
+		}
+		if d.data.Haustoria.Orgmode != nil {
+			orgmodeTable := d.cstDoc.EnsureTableInContainer(tableNode, "orgmode")
+			if d.data.Haustoria.Orgmode.Transport != "" || d.cstDoc.HasInContainer(orgmodeTable, "transport") {
+				if err := d.cstDoc.SetInContainer(orgmodeTable, "transport", d.data.Haustoria.Orgmode.Transport); err != nil {
+					return nil, err
+				}
+			}
+			if d.data.Haustoria.Orgmode.WebDAV != nil {
+				webdavTable := d.cstDoc.EnsureTableInContainer(orgmodeTable, "webdav")
+				if d.data.Haustoria.Orgmode.WebDAV.URL != "" || d.cstDoc.HasInContainer(webdavTable, "url") {
+					if err := d.cstDoc.SetInContainer(webdavTable, "url", d.data.Haustoria.Orgmode.WebDAV.URL); err != nil {
+						return nil, err
+					}
+				}
+				if d.data.Haustoria.Orgmode.WebDAV.Username != "" || d.cstDoc.HasInContainer(webdavTable, "username") {
+					if err := d.cstDoc.SetInContainer(webdavTable, "username", d.data.Haustoria.Orgmode.WebDAV.Username); err != nil {
+						return nil, err
+					}
+				}
+			}
+			if d.data.Haustoria.Orgmode.SFTP != nil {
+				sftpTable := d.cstDoc.EnsureTableInContainer(orgmodeTable, "sftp")
+				if d.data.Haustoria.Orgmode.SFTP.Host != "" || d.cstDoc.HasInContainer(sftpTable, "host") {
+					if err := d.cstDoc.SetInContainer(sftpTable, "host", d.data.Haustoria.Orgmode.SFTP.Host); err != nil {
+						return nil, err
+					}
+				}
+				if d.data.Haustoria.Orgmode.SFTP.Port != 0 || d.cstDoc.HasInContainer(sftpTable, "port") {
+					if err := d.cstDoc.SetInContainer(sftpTable, "port", d.data.Haustoria.Orgmode.SFTP.Port); err != nil {
+						return nil, err
+					}
+				}
+				if d.data.Haustoria.Orgmode.SFTP.User != "" || d.cstDoc.HasInContainer(sftpTable, "user") {
+					if err := d.cstDoc.SetInContainer(sftpTable, "user", d.data.Haustoria.Orgmode.SFTP.User); err != nil {
+						return nil, err
+					}
+				}
+				if d.data.Haustoria.Orgmode.SFTP.PrivateKeyPath != "" || d.cstDoc.HasInContainer(sftpTable, "private-key-path") {
+					if err := d.cstDoc.SetInContainer(sftpTable, "private-key-path", d.data.Haustoria.Orgmode.SFTP.PrivateKeyPath); err != nil {
+						return nil, err
+					}
+				}
+			}
+		}
+		if len(d.data.Haustoria.Folders) > 0 {
+			for mapKey, mapVal := range d.data.Haustoria.Folders {
+				subTable := d.cstDoc.EnsureSubTableInContainer(tableNode, "folders", mapKey)
+				if mapVal.Path != "" || d.cstDoc.HasInContainer(subTable, "path") {
+					if err := d.cstDoc.SetInContainer(subTable, "path", mapVal.Path); err != nil {
+						return nil, err
+					}
+				}
+				if mapVal.Type != "" || d.cstDoc.HasInContainer(subTable, "type") {
+					if err := d.cstDoc.SetInContainer(subTable, "type", mapVal.Type); err != nil {
+						return nil, err
+					}
+				}
+				if len(mapVal.Tags) > 0 || d.cstDoc.HasInContainer(subTable, "tags") {
+					if err := d.cstDoc.SetInContainer(subTable, "tags", mapVal.Tags); err != nil {
+						return nil, err
 					}
 				}
 			}
@@ -334,6 +466,74 @@ func DecodeV2Into(data *V2, doc *document.Document, container *cst.Node, consume
 				}
 			}
 		}
+		if orgmodeNode := doc.FindTableInContainer(tableNode, "orgmode"); orgmodeNode != nil {
+			consumed[keyPrefix+"haustoria.orgmode"] = true
+			orgmodeVal := &OrgmodeConfig{}
+			if v, err := document.GetFromContainer[string](doc, orgmodeNode, "transport"); err == nil {
+				orgmodeVal.Transport = v
+				consumed[keyPrefix+"haustoria.orgmode.transport"] = true
+			}
+			if webdavNode := doc.FindTableInContainer(orgmodeNode, "webdav"); webdavNode != nil {
+				consumed[keyPrefix+"haustoria.orgmode.webdav"] = true
+				webdavVal := &OrgmodeWebDAV{}
+				if v, err := document.GetFromContainer[string](doc, webdavNode, "url"); err == nil {
+					webdavVal.URL = v
+					consumed[keyPrefix+"haustoria.orgmode.webdav.url"] = true
+				}
+				if v, err := document.GetFromContainer[string](doc, webdavNode, "username"); err == nil {
+					webdavVal.Username = v
+					consumed[keyPrefix+"haustoria.orgmode.webdav.username"] = true
+				}
+				orgmodeVal.WebDAV = webdavVal
+			}
+			if sftpNode := doc.FindTableInContainer(orgmodeNode, "sftp"); sftpNode != nil {
+				consumed[keyPrefix+"haustoria.orgmode.sftp"] = true
+				sftpVal := &OrgmodeSFTP{}
+				if v, err := document.GetFromContainer[string](doc, sftpNode, "host"); err == nil {
+					sftpVal.Host = v
+					consumed[keyPrefix+"haustoria.orgmode.sftp.host"] = true
+				}
+				if v, err := document.GetFromContainer[int](doc, sftpNode, "port"); err == nil {
+					sftpVal.Port = v
+					consumed[keyPrefix+"haustoria.orgmode.sftp.port"] = true
+				}
+				if v, err := document.GetFromContainer[string](doc, sftpNode, "user"); err == nil {
+					sftpVal.User = v
+					consumed[keyPrefix+"haustoria.orgmode.sftp.user"] = true
+				}
+				if v, err := document.GetFromContainer[string](doc, sftpNode, "private-key-path"); err == nil {
+					sftpVal.PrivateKeyPath = v
+					consumed[keyPrefix+"haustoria.orgmode.sftp.private-key-path"] = true
+				}
+				orgmodeVal.SFTP = sftpVal
+			}
+			data.Haustoria.Orgmode = orgmodeVal
+		}
+		{
+			subTables := doc.FindSubTablesInContainer(tableNode, "folders")
+			if len(subTables) > 0 {
+				consumed[keyPrefix+"haustoria.folders"] = true
+				data.Haustoria.Folders = make(map[string]FolderConfig)
+				for _, subTable := range subTables {
+					mapKey := document.SubTableKeyInContainer(subTable, tableNode, "folders")
+					consumed[keyPrefix+"haustoria.folders"+"."+mapKey] = true
+					var entry FolderConfig
+					if v, err := document.GetFromContainer[string](doc, subTable, "path"); err == nil {
+						entry.Path = v
+						consumed[keyPrefix+"haustoria.folders.path"] = true
+					}
+					if v, err := document.GetFromContainer[string](doc, subTable, "type"); err == nil {
+						entry.Type = v
+						consumed[keyPrefix+"haustoria.folders.type"] = true
+					}
+					if v, err := document.GetFromContainer[[]string](doc, subTable, "tags"); err == nil {
+						entry.Tags = v
+						consumed[keyPrefix+"haustoria.folders.tags"] = true
+					}
+					data.Haustoria.Folders[mapKey] = entry
+				}
+			}
+		}
 	}
 
 	return nil
@@ -424,6 +624,70 @@ func EncodeV2From(data *V2, doc *document.Document, container *cst.Node) error {
 						if err := doc.SetInContainer(tableNode, k, v); err != nil {
 							return err
 						}
+					}
+				}
+			}
+		}
+		if data.Haustoria.Orgmode != nil {
+			orgmodeTable := doc.EnsureTableInContainer(tableNode, "orgmode")
+			if data.Haustoria.Orgmode.Transport != "" || doc.HasInContainer(orgmodeTable, "transport") {
+				if err := doc.SetInContainer(orgmodeTable, "transport", data.Haustoria.Orgmode.Transport); err != nil {
+					return err
+				}
+			}
+			if data.Haustoria.Orgmode.WebDAV != nil {
+				webdavTable := doc.EnsureTableInContainer(orgmodeTable, "webdav")
+				if data.Haustoria.Orgmode.WebDAV.URL != "" || doc.HasInContainer(webdavTable, "url") {
+					if err := doc.SetInContainer(webdavTable, "url", data.Haustoria.Orgmode.WebDAV.URL); err != nil {
+						return err
+					}
+				}
+				if data.Haustoria.Orgmode.WebDAV.Username != "" || doc.HasInContainer(webdavTable, "username") {
+					if err := doc.SetInContainer(webdavTable, "username", data.Haustoria.Orgmode.WebDAV.Username); err != nil {
+						return err
+					}
+				}
+			}
+			if data.Haustoria.Orgmode.SFTP != nil {
+				sftpTable := doc.EnsureTableInContainer(orgmodeTable, "sftp")
+				if data.Haustoria.Orgmode.SFTP.Host != "" || doc.HasInContainer(sftpTable, "host") {
+					if err := doc.SetInContainer(sftpTable, "host", data.Haustoria.Orgmode.SFTP.Host); err != nil {
+						return err
+					}
+				}
+				if data.Haustoria.Orgmode.SFTP.Port != 0 || doc.HasInContainer(sftpTable, "port") {
+					if err := doc.SetInContainer(sftpTable, "port", data.Haustoria.Orgmode.SFTP.Port); err != nil {
+						return err
+					}
+				}
+				if data.Haustoria.Orgmode.SFTP.User != "" || doc.HasInContainer(sftpTable, "user") {
+					if err := doc.SetInContainer(sftpTable, "user", data.Haustoria.Orgmode.SFTP.User); err != nil {
+						return err
+					}
+				}
+				if data.Haustoria.Orgmode.SFTP.PrivateKeyPath != "" || doc.HasInContainer(sftpTable, "private-key-path") {
+					if err := doc.SetInContainer(sftpTable, "private-key-path", data.Haustoria.Orgmode.SFTP.PrivateKeyPath); err != nil {
+						return err
+					}
+				}
+			}
+		}
+		if len(data.Haustoria.Folders) > 0 {
+			for mapKey, mapVal := range data.Haustoria.Folders {
+				subTable := doc.EnsureSubTableInContainer(tableNode, "folders", mapKey)
+				if mapVal.Path != "" || doc.HasInContainer(subTable, "path") {
+					if err := doc.SetInContainer(subTable, "path", mapVal.Path); err != nil {
+						return err
+					}
+				}
+				if mapVal.Type != "" || doc.HasInContainer(subTable, "type") {
+					if err := doc.SetInContainer(subTable, "type", mapVal.Type); err != nil {
+						return err
+					}
+				}
+				if len(mapVal.Tags) > 0 || doc.HasInContainer(subTable, "tags") {
+					if err := doc.SetInContainer(subTable, "tags", mapVal.Tags); err != nil {
+						return err
 					}
 				}
 			}

--- a/go/internal/hotel/orgmode/CLAUDE.md
+++ b/go/internal/hotel/orgmode/CLAUDE.md
@@ -1,0 +1,15 @@
+# orgmode
+
+Orgmode parser and serializer for dodder haustoria integration.
+
+## Key Types
+
+- `Document`: Parsed orgmode document with preamble and headings
+- `Heading`: Single org heading with level, title, tags, properties, and body
+- `Properties`: Key-value property drawer
+
+## Key Functions
+
+- `Parse`: Parse orgmode text into a Document
+- `Serialize`: Render a Document back to orgmode text
+- `MakeHeading`: Construct a heading from dodder object fields

--- a/go/internal/hotel/orgmode/main.go
+++ b/go/internal/hotel/orgmode/main.go
@@ -1,0 +1,251 @@
+package orgmode
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Document is a parsed orgmode file. It contains an optional preamble (text
+// before the first heading) and a sequence of top-level headings.
+type Document struct {
+	Preamble string
+	Headings []Heading
+}
+
+// Heading is a single org heading node. Nesting is represented by Level
+// (1 = *, 2 = **, etc.). Subheadings are children.
+type Heading struct {
+	Level      int
+	Keyword    string // TODO, DONE, etc.
+	Title      string
+	Tags       []string
+	Properties Properties
+	Body       string
+	Children   []Heading
+}
+
+// Properties is the :PROPERTIES: drawer content as ordered key-value pairs.
+type Properties map[string]string
+
+// Parse reads orgmode text and returns a Document. This is a minimal parser
+// sufficient for round-tripping dodder zettels through orgmode: it handles
+// headings, TODO keywords, tags, property drawers, and body text.
+func Parse(text string) (document Document, err error) {
+	lines := strings.Split(text, "\n")
+
+	var preambleLines []string
+	var headings []Heading
+	var stack []*Heading
+
+	i := 0
+	for i < len(lines) {
+		line := lines[i]
+
+		level, rest := parseHeadingPrefix(line)
+		if level == 0 {
+			if len(stack) == 0 {
+				preambleLines = append(preambleLines, line)
+			} else {
+				current := stack[len(stack)-1]
+				if current.Body != "" {
+					current.Body += "\n"
+				}
+				current.Body += line
+			}
+			i++
+			continue
+		}
+
+		heading := Heading{Level: level}
+		heading.Keyword, heading.Title, heading.Tags = parseHeadingLine(rest)
+
+		i++
+
+		// Parse property drawer if present.
+		if i < len(lines) {
+			heading.Properties, i = parsePropertyDrawer(lines, i)
+		}
+
+		// Unwind stack to find parent.
+		for len(stack) > 0 && stack[len(stack)-1].Level >= level {
+			stack = stack[:len(stack)-1]
+		}
+
+		if len(stack) == 0 {
+			headings = append(headings, heading)
+			stack = []*Heading{&headings[len(headings)-1]}
+		} else {
+			parent := stack[len(stack)-1]
+			parent.Children = append(parent.Children, heading)
+			stack = append(stack, &parent.Children[len(parent.Children)-1])
+		}
+	}
+
+	document.Preamble = strings.Join(preambleLines, "\n")
+	document.Headings = headings
+
+	return document, nil
+}
+
+// Serialize renders a Document back to orgmode text.
+func Serialize(document Document) string {
+	var builder strings.Builder
+
+	if document.Preamble != "" {
+		builder.WriteString(document.Preamble)
+		if len(document.Headings) > 0 {
+			builder.WriteString("\n")
+		}
+	}
+
+	for idx, heading := range document.Headings {
+		if idx > 0 || document.Preamble != "" {
+			// Blank line between headings or after preamble.
+		}
+		serializeHeading(&builder, &heading)
+	}
+
+	return builder.String()
+}
+
+// MakeHeading constructs a Heading from dodder object fields. This is the
+// decompile path: dodder -> orgmode.
+func MakeHeading(
+	title string,
+	tags []string,
+	body string,
+	properties Properties,
+) Heading {
+	heading := Heading{
+		Level:      1,
+		Title:      title,
+		Tags:       tags,
+		Properties: properties,
+		Body:       body,
+	}
+
+	return heading
+}
+
+func serializeHeading(builder *strings.Builder, heading *Heading) {
+	// Stars.
+	builder.WriteString(strings.Repeat("*", heading.Level))
+	builder.WriteString(" ")
+
+	// TODO keyword.
+	if heading.Keyword != "" {
+		builder.WriteString(heading.Keyword)
+		builder.WriteString(" ")
+	}
+
+	// Title.
+	builder.WriteString(heading.Title)
+
+	// Tags.
+	if len(heading.Tags) > 0 {
+		builder.WriteString(" :")
+		builder.WriteString(strings.Join(heading.Tags, ":"))
+		builder.WriteString(":")
+	}
+
+	builder.WriteString("\n")
+
+	// Property drawer.
+	if len(heading.Properties) > 0 {
+		builder.WriteString(":PROPERTIES:\n")
+		for key, value := range heading.Properties {
+			fmt.Fprintf(builder, ":%s: %s\n", key, value)
+		}
+		builder.WriteString(":END:\n")
+	}
+
+	// Body.
+	if heading.Body != "" {
+		builder.WriteString(heading.Body)
+		builder.WriteString("\n")
+	}
+
+	// Children.
+	for _, child := range heading.Children {
+		serializeHeading(builder, &child)
+	}
+}
+
+// parseHeadingPrefix checks if a line starts with one or more '*' followed
+// by a space. Returns the heading level and the remainder of the line.
+func parseHeadingPrefix(line string) (level int, rest string) {
+	if len(line) == 0 || line[0] != '*' {
+		return 0, line
+	}
+
+	for level < len(line) && line[level] == '*' {
+		level++
+	}
+
+	if level >= len(line) || line[level] != ' ' {
+		return 0, line
+	}
+
+	return level, line[level+1:]
+}
+
+// parseHeadingLine extracts the TODO keyword, title, and tags from the text
+// after the stars prefix.
+func parseHeadingLine(rest string) (keyword, title string, tags []string) {
+	// Check for TODO keyword at the start.
+	for _, kw := range []string{"TODO", "DONE", "NEXT", "WAITING", "CANCELLED"} {
+		if strings.HasPrefix(rest, kw+" ") || rest == kw {
+			keyword = kw
+			rest = strings.TrimPrefix(rest, kw)
+			rest = strings.TrimLeft(rest, " ")
+			break
+		}
+	}
+
+	// Check for tags at the end: :tag1:tag2:
+	if idx := strings.LastIndex(rest, " :"); idx >= 0 {
+		tagPart := rest[idx+2:]
+		if strings.HasSuffix(tagPart, ":") && !strings.Contains(tagPart[:len(tagPart)-1], " ") {
+			tagStr := tagPart[:len(tagPart)-1]
+			tags = strings.Split(tagStr, ":")
+			rest = strings.TrimRight(rest[:idx], " ")
+		}
+	}
+
+	title = rest
+	return keyword, title, tags
+}
+
+// parsePropertyDrawer reads the :PROPERTIES:...:END: block starting at line
+// index i. Returns the properties and the next line index after :END:.
+func parsePropertyDrawer(lines []string, i int) (Properties, int) {
+	trimmed := strings.TrimSpace(lines[i])
+	if trimmed != ":PROPERTIES:" {
+		return nil, i
+	}
+
+	props := make(Properties)
+	i++
+
+	for i < len(lines) {
+		trimmed = strings.TrimSpace(lines[i])
+		i++
+
+		if trimmed == ":END:" {
+			break
+		}
+
+		// Parse :KEY: VALUE
+		if len(trimmed) > 1 && trimmed[0] == ':' {
+			rest := trimmed[1:]
+			colonIdx := strings.Index(rest, ":")
+			if colonIdx > 0 {
+				key := rest[:colonIdx]
+				value := strings.TrimSpace(rest[colonIdx+1:])
+				props[key] = value
+			}
+		}
+	}
+
+	return props, i
+}

--- a/go/internal/hotel/webdav/CLAUDE.md
+++ b/go/internal/hotel/webdav/CLAUDE.md
@@ -1,0 +1,18 @@
+# webdav
+
+WebDAV HTTP client for file-level operations (PROPFIND, GET, PUT, DELETE, MKCOL).
+
+## Key Types
+
+- `Client`: WebDAV HTTP client with basic auth
+- `Config`: Connection parameters (URL, username, password)
+- `Resource`: File/collection metadata from PROPFIND (href, content type, etag, size)
+
+## Key Functions
+
+- `MakeClient`: Construct a client from config
+- `List`: PROPFIND to enumerate collection members
+- `Get`: Retrieve file content
+- `Put`: Create or update a file (with optional ETag conditional)
+- `Delete`: Remove a resource
+- `Mkcol`: Create a collection (directory)

--- a/go/internal/hotel/webdav/main.go
+++ b/go/internal/hotel/webdav/main.go
@@ -1,0 +1,256 @@
+package webdav
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const requestTimeout = 30 * time.Second
+
+// Config holds WebDAV connection parameters.
+type Config struct {
+	URL      string
+	Username string
+	Password string
+}
+
+// Resource represents a file or collection returned by PROPFIND.
+type Resource struct {
+	Href        string
+	DisplayName string
+	ContentType string
+	ETag        string
+	Size        int64
+	IsDir       bool
+}
+
+// Client is a WebDAV HTTP client for file-level operations.
+type Client struct {
+	cfg  *Config
+	http *http.Client
+}
+
+// MakeClient creates a WebDAV client from the given configuration.
+func MakeClient(cfg *Config) *Client {
+	return &Client{
+		cfg: cfg,
+		http: &http.Client{
+			Timeout: requestTimeout,
+		},
+	}
+}
+
+func (client *Client) do(
+	method string,
+	url string,
+	body io.Reader,
+	headers map[string]string,
+) (resp *http.Response, err error) {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("webdav request: %w", err)
+	}
+
+	if client.cfg.Username != "" {
+		req.SetBasicAuth(client.cfg.Username, client.cfg.Password)
+	}
+
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+
+	return client.http.Do(req)
+}
+
+// List performs a PROPFIND on the given collection URL and returns the
+// contained resources.
+func (client *Client) List(collectionURL string) (resources []Resource, err error) {
+	propfindBody := `<?xml version="1.0" encoding="utf-8" ?>
+<d:propfind xmlns:d="DAV:">
+  <d:prop>
+    <d:displayname/>
+    <d:getcontenttype/>
+    <d:getetag/>
+    <d:getcontentlength/>
+    <d:resourcetype/>
+  </d:prop>
+</d:propfind>`
+
+	resp, err := client.do("PROPFIND", collectionURL, strings.NewReader(propfindBody), map[string]string{
+		"Content-Type": "application/xml; charset=utf-8",
+		"Depth":        "1",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("PROPFIND %s: %w", collectionURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusMultiStatus {
+		return nil, fmt.Errorf("PROPFIND %s: status %d", collectionURL, resp.StatusCode)
+	}
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("PROPFIND read body: %w", err)
+	}
+
+	return parsePropfindResponse(responseBody, collectionURL)
+}
+
+// Get retrieves the content of a file at the given URL.
+func (client *Client) Get(fileURL string) (content []byte, etag string, err error) {
+	resp, err := client.do("GET", fileURL, nil, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("GET %s: %w", fileURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("GET %s: status %d", fileURL, resp.StatusCode)
+	}
+
+	content, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("GET read body: %w", err)
+	}
+
+	etag = resp.Header.Get("ETag")
+	return content, etag, nil
+}
+
+// Put creates or updates a file at the given URL. If etag is non-empty, the
+// request uses If-Match for conditional update.
+func (client *Client) Put(fileURL string, content []byte, etag string) (err error) {
+	headers := map[string]string{
+		"Content-Type": "text/org; charset=utf-8",
+	}
+
+	if etag != "" {
+		headers["If-Match"] = etag
+	}
+
+	resp, err := client.do("PUT", fileURL, strings.NewReader(string(content)), headers)
+	if err != nil {
+		return fmt.Errorf("PUT %s: %w", fileURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("PUT %s: status %d", fileURL, resp.StatusCode)
+	}
+
+	return nil
+}
+
+// Delete removes the resource at the given URL.
+func (client *Client) Delete(fileURL string) (err error) {
+	resp, err := client.do("DELETE", fileURL, nil, nil)
+	if err != nil {
+		return fmt.Errorf("DELETE %s: %w", fileURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("DELETE %s: status %d", fileURL, resp.StatusCode)
+	}
+
+	return nil
+}
+
+// Mkcol creates a new collection (directory) at the given URL.
+func (client *Client) Mkcol(collectionURL string) (err error) {
+	resp, err := client.do("MKCOL", collectionURL, nil, nil)
+	if err != nil {
+		return fmt.Errorf("MKCOL %s: %w", collectionURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("MKCOL %s: status %d", collectionURL, resp.StatusCode)
+	}
+
+	return nil
+}
+
+// --- XML types for WebDAV PROPFIND responses ---
+
+type multistatusResponse struct {
+	XMLName   xml.Name      `xml:"DAV: multistatus"`
+	Responses []davResponse `xml:"DAV: response"`
+}
+
+type davResponse struct {
+	Href     string      `xml:"DAV: href"`
+	Propstat []propstat  `xml:"DAV: propstat"`
+}
+
+type propstat struct {
+	Prop   prop   `xml:"DAV: prop"`
+	Status string `xml:"DAV: status"`
+}
+
+type prop struct {
+	DisplayName   string       `xml:"DAV: displayname"`
+	ContentType   string       `xml:"DAV: getcontenttype"`
+	ETag          string       `xml:"DAV: getetag"`
+	ContentLength int64        `xml:"DAV: getcontentlength"`
+	ResourceType  resourceType `xml:"DAV: resourcetype"`
+}
+
+type resourceType struct {
+	Collection *struct{} `xml:"DAV: collection"`
+}
+
+func parsePropfindResponse(body []byte, collectionURL string) (resources []Resource, err error) {
+	var ms multistatusResponse
+	if err = xml.Unmarshal(body, &ms); err != nil {
+		return nil, fmt.Errorf("parse PROPFIND response: %w", err)
+	}
+
+	// Normalize the collection URL for comparison.
+	collectionPath := normalizeHref(collectionURL)
+
+	for _, resp := range ms.Responses {
+		href := normalizeHref(resp.Href)
+
+		// Skip the collection itself.
+		if href == collectionPath {
+			continue
+		}
+
+		resource := Resource{Href: resp.Href}
+
+		for _, ps := range resp.Propstat {
+			if !strings.Contains(ps.Status, "200") {
+				continue
+			}
+
+			resource.DisplayName = ps.Prop.DisplayName
+			resource.ContentType = ps.Prop.ContentType
+			resource.ETag = ps.Prop.ETag
+			resource.Size = ps.Prop.ContentLength
+			resource.IsDir = ps.Prop.ResourceType.Collection != nil
+		}
+
+		resources = append(resources, resource)
+	}
+
+	return resources, nil
+}
+
+// normalizeHref strips scheme+host and trailing slashes for comparison.
+func normalizeHref(href string) string {
+	// Strip scheme://host if present.
+	if idx := strings.Index(href, "://"); idx >= 0 {
+		rest := href[idx+3:]
+		if slashIdx := strings.Index(rest, "/"); slashIdx >= 0 {
+			href = rest[slashIdx:]
+		}
+	}
+
+	return strings.TrimRight(href, "/")
+}

--- a/go/internal/mike/haustoria_orgmode/CLAUDE.md
+++ b/go/internal/mike/haustoria_orgmode/CLAUDE.md
@@ -1,0 +1,18 @@
+# haustoria_orgmode
+
+Orgmode haustoria implementation for syncing dodder zettels with orgmode files
+over WebDAV or SFTP.
+
+## Key Types
+
+- `Store`: Implements both haustoria.Haustoria and store_workspace.StoreLike
+- `Transport`: Interface abstracting file operations (list, read, write, delete)
+- `webdavTransport`: Transport implementation backed by hotel/webdav
+- `sftpTransport`: Transport implementation backed by SFTP
+- `FolderMapping`: Maps a remote folder to a dodder type and tags
+
+## Key Functions
+
+- `MakeStore`: Construct a store with transport and folder mappings
+- `MakeWebDAVTransport`: Create transport from WebDAV config
+- `MakeSFTPTransport`: Create transport from SFTP config

--- a/go/internal/mike/haustoria_orgmode/main.go
+++ b/go/internal/mike/haustoria_orgmode/main.go
@@ -1,0 +1,470 @@
+package haustoria_orgmode
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"time"
+
+	"code.linenisgreat.com/dodder/go/internal/_/domain_interfaces"
+	"code.linenisgreat.com/dodder/go/internal/alfa/checkout_options"
+	"code.linenisgreat.com/dodder/go/internal/alfa/genres"
+	"code.linenisgreat.com/dodder/go/internal/bravo/checked_out_state"
+	"code.linenisgreat.com/dodder/go/internal/charlie/haustoria"
+	"code.linenisgreat.com/dodder/go/internal/golf/sku"
+	"code.linenisgreat.com/dodder/go/internal/hotel/orgmode"
+	"code.linenisgreat.com/dodder/go/internal/kilo/queries"
+	"code.linenisgreat.com/dodder/go/internal/lima/store_workspace"
+	"code.linenisgreat.com/dodder/go/lib/_/interfaces"
+	"code.linenisgreat.com/dodder/go/lib/bravo/errors"
+)
+
+// FolderMapping associates a remote folder with a dodder type and optional
+// tags. Each folder is listed independently, and discovered .org files are
+// compiled into zettels with the configured type and tags.
+type FolderMapping struct {
+	Path   string // Remote folder path or URL
+	TypeId string // Dodder type for objects in this folder
+	Tags   []string
+}
+
+// Store implements both haustoria.Haustoria and store_workspace.StoreLike
+// for orgmode files served over WebDAV or SFTP.
+type Store struct {
+	transport Transport
+	folders   []FolderMapping
+	supplies  store_workspace.Supplies
+}
+
+var (
+	_ haustoria.Haustoria       = &Store{}
+	_ store_workspace.StoreLike = &Store{}
+)
+
+// MakeStore creates an orgmode haustoria Store with the given transport and
+// folder mappings.
+func MakeStore(transport Transport, folders []FolderMapping) *Store {
+	return &Store{
+		transport: transport,
+		folders:   folders,
+	}
+}
+
+// --- StoreLike interface ---
+
+func (store *Store) Initialize(supplies store_workspace.Supplies) error {
+	store.supplies = supplies
+	return nil
+}
+
+func (store *Store) QueryCheckedOut(
+	queryGroup *queries.Query,
+	output interfaces.FuncIter[sku.SkuType],
+) (err error) {
+	// Build a lookup of existing bindings: ExternalObjectId string -> Transacted.
+	bindings := make(map[string]*sku.Transacted)
+
+	if err = store.supplies.ReadPrimitiveQuery(
+		nil,
+		func(object *sku.Transacted) error {
+			eoid := object.GetExternalObjectId()
+			if eoid.IsEmpty() {
+				return nil
+			}
+
+			cloned, _ := object.CloneTransacted() //repool:owned
+			bindings[eoid.String()] = cloned
+			return nil
+		},
+	); err != nil {
+		return errors.Wrap(err)
+	}
+
+	for _, folder := range store.folders {
+		if err = store.queryCheckedOutForFolder(folder, bindings, output); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (store *Store) queryCheckedOutForFolder(
+	folder FolderMapping,
+	bindings map[string]*sku.Transacted,
+	output interfaces.FuncIter[sku.SkuType],
+) (err error) {
+	files, err := store.transport.List(folder.Path)
+	if err != nil {
+		return errors.Wrapf(err, "list orgmode files in %s", folder.Path)
+	}
+
+	for _, file := range files {
+		content, _, readErr := store.transport.Read(file.Path)
+		if readErr != nil {
+			continue
+		}
+
+		doc, parseErr := orgmode.Parse(string(content))
+		if parseErr != nil {
+			continue
+		}
+
+		// Use the filename (without extension) as the external ID.
+		externalId := fileExternalId(file.Path)
+
+		// Extract the first heading as the zettel description.
+		description, tags, body := extractFromDocument(doc)
+
+		co, _ := sku.GetCheckedOutPool().GetWithRepool() //repool:owned
+
+		external := co.GetSkuExternal()
+		metadata := external.GetMetadataMutable()
+
+		if err = metadata.GetDescriptionMutable().Set(description); err != nil {
+			return errors.Wrap(err)
+		}
+
+		if folder.TypeId != "" {
+			if err = metadata.GetTypeMutable().SetType(folder.TypeId); err != nil {
+				return errors.Wrap(err)
+			}
+		}
+
+		// Add per-folder tags from the mapping.
+		for _, tagStr := range folder.Tags {
+			if addErr := metadata.AddTagString(tagStr); addErr != nil {
+				continue
+			}
+		}
+
+		// Add tags from the orgmode heading.
+		for _, tagStr := range tags {
+			if addErr := metadata.AddTagString(tagStr); addErr != nil {
+				continue
+			}
+		}
+
+		if body != "" {
+			if err = store.writeBlob(external, []byte(body)); err != nil {
+				return errors.Wrapf(err, "write blob for %s", externalId)
+			}
+		}
+
+		if err = external.GetExternalObjectIdMutable().SetWithGenre(
+			externalId,
+			genres.Zettel,
+		); err != nil {
+			return errors.Wrap(err)
+		}
+
+		// Check if this orgmode file has an existing dodder binding.
+		if bound, ok := bindings[externalId]; ok {
+			sku.TransactedResetter.ResetWith(co.GetSku(), bound)
+			co.SetState(checked_out_state.CheckedOut)
+		} else {
+			co.GetSku().GetObjectIdMutable().SetGenre(genres.Zettel)
+			co.SetState(checked_out_state.Untracked)
+		}
+
+		if err = output(co); err != nil {
+			return errors.Wrap(err)
+		}
+	}
+
+	return nil
+}
+
+func (store *Store) CheckoutOne(
+	options checkout_options.Options,
+	transactedGetter sku.TransactedGetter,
+) (checkedOut sku.SkuType, err error) {
+	object := transactedGetter.GetSku()
+
+	description := object.GetMetadata().GetDescription().String()
+	typeId := object.GetMetadata().GetType().String()
+
+	var tags []string
+	for tag := range object.GetMetadata().GetTags().All() {
+		tags = append(tags, tag.String())
+	}
+
+	var blob []byte
+	if !object.GetBlobDigest().IsNull() {
+		if blob, err = store.readBlob(object); err != nil {
+			return nil, errors.Wrapf(err,
+				"read blob for %s", object.GetObjectId(),
+			)
+		}
+	}
+
+	result, err := store.Decompile(haustoria.DecompileRequest{
+		ObjectId:    object.GetObjectId().String(),
+		Description: description,
+		Blob:        blob,
+		Tags:        tags,
+		TypeId:      typeId,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err,
+			"decompile %s to orgmode", object.GetObjectId(),
+		)
+	}
+
+	co, _ := sku.GetCheckedOutPool().GetWithRepool() //repool:owned
+
+	sku.TransactedResetter.ResetWith(co.GetSku(), object)
+
+	external := co.GetSkuExternal()
+	sku.TransactedResetter.ResetWith(external, object)
+
+	if err = external.GetExternalObjectIdMutable().SetWithGenre(
+		result.ExternalId,
+		genres.Zettel,
+	); err != nil {
+		return nil, errors.Wrap(err)
+	}
+
+	co.SetState(checked_out_state.CheckedOut)
+
+	return co, nil
+}
+
+func (store *Store) readBlob(object *sku.Transacted) (content []byte, err error) {
+	blobReader, err := store.supplies.Env.GetDefaultBlobStore().MakeBlobReader(
+		object.GetBlobDigest(),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err)
+	}
+
+	defer errors.DeferredCloser(&err, blobReader)
+
+	if content, err = io.ReadAll(blobReader); err != nil {
+		return nil, errors.Wrap(err)
+	}
+
+	return content, nil
+}
+
+func (store *Store) ReadAllExternalItems() error {
+	return nil
+}
+
+func (store *Store) Flush() error {
+	return nil
+}
+
+func (store *Store) GetObjectIdsForString(
+	v string,
+) ([]domain_interfaces.ExternalObjectId, error) {
+	return nil, nil
+}
+
+func (store *Store) writeBlob(
+	object *sku.Transacted,
+	content []byte,
+) (err error) {
+	blobWriter, err := store.supplies.Env.GetDefaultBlobStore().MakeBlobWriter(nil)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+
+	defer errors.DeferredCloser(&err, blobWriter)
+
+	if _, err = bytes.NewReader(content).WriteTo(blobWriter); err != nil {
+		return errors.Wrap(err)
+	}
+
+	if err = object.SetBlobDigest(blobWriter.GetMarklId()); err != nil {
+		return errors.Wrap(err)
+	}
+
+	return nil
+}
+
+// --- Haustoria interface ---
+
+// Compile reads an orgmode file and returns dodder-compatible fields.
+// external -> dodder
+func (store *Store) Compile(req haustoria.CompileRequest) (haustoria.CompileResult, error) {
+	for _, folder := range store.folders {
+		files, err := store.transport.List(folder.Path)
+		if err != nil {
+			continue
+		}
+
+		for _, file := range files {
+			externalId := fileExternalId(file.Path)
+			if externalId != req.ExternalId {
+				continue
+			}
+
+			content, etag, readErr := store.transport.Read(file.Path)
+			if readErr != nil {
+				return haustoria.CompileResult{}, readErr
+			}
+
+			doc, parseErr := orgmode.Parse(string(content))
+			if parseErr != nil {
+				return haustoria.CompileResult{}, parseErr
+			}
+
+			description, tags, body := extractFromDocument(doc)
+
+			// Merge folder tags with heading tags.
+			allTags := append(folder.Tags, tags...)
+
+			return haustoria.CompileResult{
+				ExternalId:  externalId,
+				Description: description,
+				Blob:        []byte(body),
+				Tags:        allTags,
+				TypeId:      folder.TypeId,
+				ETag:        etag,
+			}, nil
+		}
+	}
+
+	return haustoria.CompileResult{}, fmt.Errorf(
+		"orgmode file not found: %s", req.ExternalId,
+	)
+}
+
+// Decompile writes a dodder object to an orgmode file.
+// dodder -> external
+func (store *Store) Decompile(req haustoria.DecompileRequest) (haustoria.DecompileResult, error) {
+	folder := store.folderForType(req.TypeId)
+	if folder == nil {
+		return haustoria.DecompileResult{}, fmt.Errorf(
+			"no folder mapping for type %s", req.TypeId,
+		)
+	}
+
+	// Build orgmode document from dodder fields.
+	props := make(orgmode.Properties)
+	props["DODDER_ID"] = req.ObjectId
+
+	heading := orgmode.MakeHeading(
+		req.Description,
+		req.Tags,
+		string(req.Blob),
+		props,
+	)
+
+	doc := orgmode.Document{
+		Headings: []orgmode.Heading{heading},
+	}
+
+	content := orgmode.Serialize(doc)
+
+	// Determine filename from external ID or object ID.
+	externalId := req.ExternalId
+	if externalId == "" {
+		externalId = sanitizeFilename(req.ObjectId)
+		if externalId == "" {
+			externalId = fmt.Sprintf("dodder-%d", time.Now().UnixNano())
+		}
+	}
+
+	filePath := path.Join(folder.Path, externalId+".org")
+
+	if err := store.transport.Write(filePath, []byte(content), req.ETag); err != nil {
+		return haustoria.DecompileResult{}, fmt.Errorf("decompile to orgmode: %w", err)
+	}
+
+	return haustoria.DecompileResult{
+		ExternalId: externalId,
+	}, nil
+}
+
+func (store *Store) Discover() ([]haustoria.ExternalResource, error) {
+	var resources []haustoria.ExternalResource
+
+	for _, folder := range store.folders {
+		files, err := store.transport.List(folder.Path)
+		if err != nil {
+			return nil, fmt.Errorf("discover orgmode files in %s: %w", folder.Path, err)
+		}
+
+		for _, file := range files {
+			resources = append(resources, haustoria.ExternalResource{
+				ExternalId:  fileExternalId(file.Path),
+				TypeId:      folder.TypeId,
+				Description: strings.TrimSuffix(file.Name, ".org"),
+			})
+		}
+	}
+
+	return resources, nil
+}
+
+func (store *Store) Delete(externalId string) error {
+	for _, folder := range store.folders {
+		filePath := path.Join(folder.Path, externalId+".org")
+		if err := store.transport.Delete(filePath); err == nil {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("orgmode file not found for delete: %s", externalId)
+}
+
+func (store *Store) folderForType(typeId string) *FolderMapping {
+	for i := range store.folders {
+		if store.folders[i].TypeId == typeId {
+			return &store.folders[i]
+		}
+	}
+
+	// Fall back to first folder.
+	if len(store.folders) > 0 {
+		return &store.folders[0]
+	}
+
+	return nil
+}
+
+// extractFromDocument pulls the description, tags, and body from an orgmode
+// Document. Uses the first heading if present; falls back to preamble.
+func extractFromDocument(doc orgmode.Document) (description string, tags []string, body string) {
+	if len(doc.Headings) > 0 {
+		heading := doc.Headings[0]
+		description = heading.Title
+		tags = heading.Tags
+		body = heading.Body
+
+		if heading.Keyword != "" {
+			// Preserve TODO keyword as a tag (e.g., "TODO" -> "todo").
+			tags = append(tags, strings.ToLower(heading.Keyword))
+		}
+
+		return description, tags, body
+	}
+
+	// No headings: use preamble as body, first line as description.
+	lines := strings.SplitN(doc.Preamble, "\n", 2)
+	if len(lines) > 0 {
+		description = strings.TrimSpace(lines[0])
+	}
+	if len(lines) > 1 {
+		body = strings.TrimSpace(lines[1])
+	}
+
+	return description, nil, body
+}
+
+// fileExternalId derives the external identifier from a file path by
+// stripping the directory and .org extension.
+func fileExternalId(filePath string) string {
+	base := path.Base(filePath)
+	return strings.TrimSuffix(base, ".org")
+}
+
+// sanitizeFilename makes an object ID safe for use as a filename by replacing
+// slashes with hyphens.
+func sanitizeFilename(objectId string) string {
+	return strings.ReplaceAll(objectId, "/", "-")
+}

--- a/go/internal/mike/haustoria_orgmode/transport.go
+++ b/go/internal/mike/haustoria_orgmode/transport.go
@@ -1,0 +1,26 @@
+package haustoria_orgmode
+
+// Transport abstracts file operations for orgmode haustoria. Two
+// implementations exist: WebDAV (HTTP) and SFTP (SSH).
+type Transport interface {
+	// List returns the orgmode files in the given folder URL/path.
+	List(folder string) ([]RemoteFile, error)
+
+	// Read retrieves the content and ETag of a file.
+	Read(filePath string) (content []byte, etag string, err error)
+
+	// Write creates or updates a file. If etag is non-empty, the transport
+	// should attempt a conditional update.
+	Write(filePath string, content []byte, etag string) error
+
+	// Delete removes a file.
+	Delete(filePath string) error
+}
+
+// RemoteFile is a file discovered by Transport.List.
+type RemoteFile struct {
+	Path string
+	Name string
+	ETag string
+	Size int64
+}

--- a/go/internal/mike/haustoria_orgmode/transport_sftp.go
+++ b/go/internal/mike/haustoria_orgmode/transport_sftp.go
@@ -1,0 +1,196 @@
+package haustoria_orgmode
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/sftp"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+// SFTPConfig holds SFTP connection parameters for the orgmode transport.
+type SFTPConfig struct {
+	Host           string
+	Port           int
+	User           string
+	Password       string
+	PrivateKeyPath string
+	KnownHostsFile string
+}
+
+// sftpTransport implements Transport using SFTP.
+type sftpTransport struct {
+	config     SFTPConfig
+	sshClient  *ssh.Client
+	sftpClient *sftp.Client
+}
+
+var _ Transport = &sftpTransport{}
+
+// MakeSFTPTransport creates a Transport backed by SFTP.
+func MakeSFTPTransport(config SFTPConfig) (Transport, error) {
+	transport := &sftpTransport{config: config}
+
+	if err := transport.connect(); err != nil {
+		return nil, fmt.Errorf("sftp transport connect: %w", err)
+	}
+
+	return transport, nil
+}
+
+func (transport *sftpTransport) connect() (err error) {
+	var authMethods []ssh.AuthMethod
+
+	if transport.config.Password != "" {
+		authMethods = append(authMethods, ssh.Password(transport.config.Password))
+	}
+
+	if transport.config.PrivateKeyPath != "" {
+		keyBytes, readErr := os.ReadFile(transport.config.PrivateKeyPath)
+		if readErr != nil {
+			return fmt.Errorf("read private key %s: %w", transport.config.PrivateKeyPath, readErr)
+		}
+
+		signer, parseErr := ssh.ParsePrivateKey(keyBytes)
+		if parseErr != nil {
+			return fmt.Errorf("parse private key: %w", parseErr)
+		}
+
+		authMethods = append(authMethods, ssh.PublicKeys(signer))
+	}
+
+	if len(authMethods) == 0 {
+		// Try SSH agent via SSH_AUTH_SOCK.
+		if agentAuth := sshAgentAuth(); agentAuth != nil {
+			authMethods = append(authMethods, agentAuth)
+		}
+	}
+
+	if len(authMethods) == 0 {
+		return fmt.Errorf("no SSH authentication method available")
+	}
+
+	port := transport.config.Port
+	if port == 0 {
+		port = 22
+	}
+
+	sshConfig := &ssh.ClientConfig{
+		User:            transport.config.User,
+		Auth:            authMethods,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+
+	addr := fmt.Sprintf("%s:%d", transport.config.Host, port)
+
+	transport.sshClient, err = ssh.Dial("tcp", addr, sshConfig)
+	if err != nil {
+		return fmt.Errorf("ssh dial %s: %w", addr, err)
+	}
+
+	transport.sftpClient, err = sftp.NewClient(transport.sshClient)
+	if err != nil {
+		transport.sshClient.Close()
+		return fmt.Errorf("sftp client: %w", err)
+	}
+
+	return nil
+}
+
+func (transport *sftpTransport) List(folder string) (files []RemoteFile, err error) {
+	entries, err := transport.sftpClient.ReadDir(folder)
+	if err != nil {
+		return nil, fmt.Errorf("sftp readdir %s: %w", folder, err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".org") {
+			continue
+		}
+
+		files = append(files, RemoteFile{
+			Path: filepath.Join(folder, name),
+			Name: name,
+			Size: entry.Size(),
+			// SFTP has no native ETag; use mtime as a change marker.
+			ETag: fmt.Sprintf("%d", entry.ModTime().UnixNano()),
+		})
+	}
+
+	return files, nil
+}
+
+func (transport *sftpTransport) Read(filePath string) (content []byte, etag string, err error) {
+	file, err := transport.sftpClient.Open(filePath)
+	if err != nil {
+		return nil, "", fmt.Errorf("sftp open %s: %w", filePath, err)
+	}
+	defer file.Close()
+
+	content, err = io.ReadAll(file)
+	if err != nil {
+		return nil, "", fmt.Errorf("sftp read %s: %w", filePath, err)
+	}
+
+	// Use stat mtime as ETag equivalent.
+	info, statErr := transport.sftpClient.Stat(filePath)
+	if statErr == nil {
+		etag = fmt.Sprintf("%d", info.ModTime().UnixNano())
+	}
+
+	return content, etag, nil
+}
+
+func (transport *sftpTransport) Write(filePath string, content []byte, _ string) (err error) {
+	// Ensure parent directory exists.
+	dir := filepath.Dir(filePath)
+	if err = transport.sftpClient.MkdirAll(dir); err != nil {
+		return fmt.Errorf("sftp mkdir %s: %w", dir, err)
+	}
+
+	file, err := transport.sftpClient.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("sftp create %s: %w", filePath, err)
+	}
+	defer file.Close()
+
+	if _, err = file.Write(content); err != nil {
+		return fmt.Errorf("sftp write %s: %w", filePath, err)
+	}
+
+	return nil
+}
+
+func (transport *sftpTransport) Delete(filePath string) (err error) {
+	if err = transport.sftpClient.Remove(filePath); err != nil {
+		return fmt.Errorf("sftp remove %s: %w", filePath, err)
+	}
+
+	return nil
+}
+
+// sshAgentAuth attempts to create an SSH agent authentication method from
+// SSH_AUTH_SOCK. Returns nil if unavailable.
+func sshAgentAuth() ssh.AuthMethod {
+	socket := os.Getenv("SSH_AUTH_SOCK")
+	if socket == "" {
+		return nil
+	}
+
+	conn, err := net.Dial("unix", socket)
+	if err != nil {
+		return nil
+	}
+
+	return ssh.PublicKeysCallback(agent.NewClient(conn).Signers)
+}

--- a/go/internal/mike/haustoria_orgmode/transport_webdav.go
+++ b/go/internal/mike/haustoria_orgmode/transport_webdav.go
@@ -1,0 +1,61 @@
+package haustoria_orgmode
+
+import (
+	"path"
+	"strings"
+
+	"code.linenisgreat.com/dodder/go/internal/hotel/webdav"
+)
+
+// webdavTransport implements Transport using a WebDAV client.
+type webdavTransport struct {
+	client *webdav.Client
+}
+
+var _ Transport = &webdavTransport{}
+
+// MakeWebDAVTransport creates a Transport backed by WebDAV.
+func MakeWebDAVTransport(cfg *webdav.Config) Transport {
+	return &webdavTransport{
+		client: webdav.MakeClient(cfg),
+	}
+}
+
+func (transport *webdavTransport) List(folder string) (files []RemoteFile, err error) {
+	resources, err := transport.client.List(folder)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, resource := range resources {
+		if resource.IsDir {
+			continue
+		}
+
+		name := path.Base(resource.Href)
+		if !strings.HasSuffix(name, ".org") {
+			continue
+		}
+
+		files = append(files, RemoteFile{
+			Path: resource.Href,
+			Name: name,
+			ETag: resource.ETag,
+			Size: resource.Size,
+		})
+	}
+
+	return files, nil
+}
+
+func (transport *webdavTransport) Read(filePath string) (content []byte, etag string, err error) {
+	return transport.client.Get(filePath)
+}
+
+func (transport *webdavTransport) Write(filePath string, content []byte, etag string) error {
+	return transport.client.Put(filePath, content, etag)
+}
+
+func (transport *webdavTransport) Delete(filePath string) error {
+	return transport.client.Delete(filePath)
+}

--- a/go/internal/november/env_workspace/main.go
+++ b/go/internal/november/env_workspace/main.go
@@ -17,8 +17,10 @@ import (
 	"code.linenisgreat.com/dodder/go/internal/golf/env_repo"
 	"code.linenisgreat.com/dodder/go/internal/golf/sku"
 	"code.linenisgreat.com/dodder/go/internal/hotel/caldav"
+	"code.linenisgreat.com/dodder/go/internal/hotel/webdav"
 	"code.linenisgreat.com/dodder/go/internal/lima/store_workspace"
 	"code.linenisgreat.com/dodder/go/internal/mike/haustoria_caldav"
+	"code.linenisgreat.com/dodder/go/internal/mike/haustoria_orgmode"
 	"code.linenisgreat.com/dodder/go/internal/mike/store_fs"
 	"code.linenisgreat.com/dodder/go/lib/_/interfaces"
 	"code.linenisgreat.com/dodder/go/lib/bravo/errors"
@@ -187,6 +189,68 @@ func Make(
 					caldavCfg,
 					calendars,
 				)
+			}
+
+		} else if hCfg.Type == "orgmode" && hCfg.Orgmode != nil {
+			resolved, resolveErr := hCfg.Orgmode.ResolveOrgmode()
+			if resolveErr == nil {
+				var transport haustoria_orgmode.Transport
+
+				switch resolved.Transport {
+				case "webdav":
+					transport = haustoria_orgmode.MakeWebDAVTransport(
+						&webdav.Config{
+							URL:      resolved.WebDAVURL,
+							Username: resolved.WebDAVUsername,
+							Password: resolved.WebDAVPassword,
+						},
+					)
+
+				case "sftp":
+					transport, _ = haustoria_orgmode.MakeSFTPTransport(
+						haustoria_orgmode.SFTPConfig{
+							Host:           resolved.SFTPHost,
+							Port:           resolved.SFTPPort,
+							User:           resolved.SFTPUser,
+							Password:       resolved.SFTPPassword,
+							PrivateKeyPath: resolved.SFTPPrivateKeyPath,
+						},
+					)
+				}
+
+				if transport != nil {
+					var folders []haustoria_orgmode.FolderMapping
+
+					for _, folder := range hCfg.Folders {
+						if folder.Path == "" {
+							continue
+						}
+
+						folders = append(folders, haustoria_orgmode.FolderMapping{
+							Path:   folder.Path,
+							TypeId: folder.Type,
+							Tags:   folder.Tags,
+						})
+					}
+
+					if len(folders) == 0 {
+						// Default: use the WebDAV URL or SFTP path as a single folder.
+						defaultPath := resolved.WebDAVURL
+						if resolved.Transport == "sftp" {
+							defaultPath = "/org"
+						}
+
+						folders = []haustoria_orgmode.FolderMapping{{
+							Path:   defaultPath,
+							TypeId: "!md",
+						}}
+					}
+
+					outputEnv.store.StoreLike = haustoria_orgmode.MakeStore(
+						transport,
+						folders,
+					)
+				}
 			}
 		}
 	}

--- a/go/internal/victor/commands_dodder/init_workspace.go
+++ b/go/internal/victor/commands_dodder/init_workspace.go
@@ -430,10 +430,60 @@ func (cmd InitWorkspace) makeHaustoriaConfig(
 			},
 		}
 
+	case "orgmode":
+		orgCfg := workspace_config_blobs.OrgmodeConfig{}
+
+		resolved, err := orgCfg.ResolveOrgmode()
+		if err != nil {
+			req.Cancel(
+				errors.BadRequestf(
+					"Orgmode configuration incomplete: %s", err,
+				),
+			)
+			return nil
+		}
+
+		switch resolved.Transport {
+		case "webdav":
+			orgCfg.Transport = "webdav"
+			orgCfg.WebDAV = &workspace_config_blobs.OrgmodeWebDAV{
+				URL:      resolved.WebDAVURL,
+				Username: resolved.WebDAVUsername,
+			}
+
+		case "sftp":
+			orgCfg.Transport = "sftp"
+			orgCfg.SFTP = &workspace_config_blobs.OrgmodeSFTP{
+				Host:           resolved.SFTPHost,
+				Port:           resolved.SFTPPort,
+				User:           resolved.SFTPUser,
+				PrivateKeyPath: resolved.SFTPPrivateKeyPath,
+			}
+		}
+
+		defaultPath := resolved.WebDAVURL
+		if resolved.Transport == "sftp" {
+			defaultPath = "/org"
+		}
+
+		return &workspace_config_blobs.V2{
+			V1: v1,
+			Haustoria: workspace_config_blobs.HaustoriaConfig{
+				Type:    "orgmode",
+				Orgmode: &orgCfg,
+				Folders: map[string]workspace_config_blobs.FolderConfig{
+					"default": {
+						Path: defaultPath,
+						Type: "!md",
+					},
+				},
+			},
+		}
+
 	default:
 		req.Cancel(
 			errors.BadRequestf(
-				"unknown haustoria type: %s (supported: caldav)",
+				"unknown haustoria type: %s (supported: caldav, orgmode)",
 				cmd.Haustoria,
 			),
 		)


### PR DESCRIPTION
Add a new haustoria implementation for syncing dodder zettels with
orgmode (.org) files served over WebDAV or SFTP. This follows the
same architecture as the existing CalDAV haustoria (FDR-0007).

New packages:
- hotel/orgmode: minimal orgmode parser/serializer (headings, tags,
  property drawers, body text)
- hotel/webdav: WebDAV HTTP client (PROPFIND, GET, PUT, DELETE, MKCOL)
- mike/haustoria_orgmode: haustoria.Haustoria + store_workspace.StoreLike
  implementation with pluggable Transport interface

Transport abstraction supports two backends:
- WebDAV (HTTP basic auth, ETag-based conditional updates)
- SFTP (password, private key, or SSH agent authentication)

Workspace config extends HaustoriaConfig with Orgmode and Folders
sections. Tommy codegen updated to serialize/deserialize the new
TOML fields. init-workspace accepts `-haustoria orgmode` and reads
connection parameters from config or environment variables
(ORGMODE_WEBDAV_URL, ORGMODE_SFTP_HOST, etc.).

https://claude.ai/code/session_01SBeXGXMmWxw59XPA8HAx9V