### PR TITLE
plan: !task type at genesis + haustoria-side VTODO field mapping

### DIFF
--- a/docs/plans/2026-04-05-fields-doddish-organize-design.md
+++ b/docs/plans/2026-04-05-fields-doddish-organize-design.md
@@ -23,6 +23,15 @@ Date: 2026-04-05
 - #98 --- resolved: infix `status^=todo` doesn't work due to `^` being
   `operatorTypeSoloSeq`; use prefix `^status=todo` instead
 - Organize internal/external fork resolution needs cleanup and more tests
+- #101 --- `fields-writer` should support blob-less first writes. Currently
+  `papa/store/field_writer.go:25-27` early-returns when the daughter has no blob
+  digest, so the writer can't create a blob from scratch when fields are set
+  programmatically. Blocks the haustoria use case in PR #100 and any future
+  "construct object from fields" code path.
+- #102 --- when `[fields-reader]` is configured but `[fields-writer]` is not,
+  organize edits are silently dropped AND fields appear duplicated in
+  `dodder show` output (`status=todo status=todo`). Two regressions in one
+  output line, exposed by PR #100 probes.
 
 ## Problem
 

--- a/docs/plans/2026-04-06-task-type-genesis-and-haustoria-fields.md
+++ b/docs/plans/2026-04-06-task-type-genesis-and-haustoria-fields.md
@@ -53,14 +53,14 @@ vim-syntax-type = "toml"
 [[fields]]
 name = "status"
 kind = "enum"
-values = ["todo", "in-process", "done", "cancelled"]
+values = ["todo", "in_progress", "done", "cancelled"]
 default = "todo"
 
 [[fields]]
 name = "priority"
 kind = "enum"
 values = ["p0", "p1", "p2", "p3"]
-default = "p0"
+default = "p3"
 
 [[fields]]
 name = "due"
@@ -90,16 +90,17 @@ Status enum values match the field-mutation work in `19c6f63` ("use 'done'
 instead of 'completed'"). The mapping to/from VTODO STATUS is the haustoria's
 job (see §3 below).
 
-`priority` is an enum with values `p0` / `p1` / `p2` / `p3` corresponding to the
-tasks.org convention (none / `!` / `!!` / `!!!`). The numeric VTODO PRIORITY
-mapping is the haustoria's job:
+`priority` is an enum with values `p0` / `p1` / `p2` / `p3` where `p0` is
+the highest priority (matches the "P0 / sev-0" ticket-tracker convention).
+The mapping to/from VTODO PRIORITY and the tasks.org `!`/`!!`/`!!!`
+convention is the haustoria's job:
 
-  VTODO PRIORITY   `!task` priority   tasks.org
-  ---------------- ------------------ -----------
-  0 (or absent)    `p0`               (none)
-  9                `p1`               `!`
-  5                `p2`               `!!`
-  1                `p3`               `!!!`
+| `!task` priority | VTODO PRIORITY | tasks.org |
+|------------------|----------------|-----------|
+| `p0`             | 1              | `!!!`     |
+| `p1`             | 5              | `!!`      |
+| `p2`             | 9              | `!`       |
+| `p3`             | 0 (or absent)  | (none)    |
 
 Other PRIORITY values fall back to the closest bucket on read; on write the
 haustoria emits the canonical numeric value above.
@@ -219,8 +220,8 @@ if err := s.writeBlob(external, blob); err != nil {
 `buildTaskTomlBlob` is a small Go function that emits TOML like:
 
 ```toml
-status = "in-process"
-priority = "p2"
+status = "in_progress"
+priority = "p1"
 due = "20260415T120000Z"
 ```
 
@@ -232,7 +233,7 @@ The status and priority values come from the mapping tables below.
 |----------------|---------------------|
 | (absent)       | `todo`              |
 | `NEEDS-ACTION` | `todo`              |
-| `IN-PROCESS`   | `in-process`        |
+| `IN-PROCESS`   | `in_progress`       |
 | `COMPLETED`    | `done`              |
 | `CANCELLED`    | `cancelled`         |
 
@@ -246,8 +247,8 @@ and priority mappings, and emits a VTODO. The current decompile hardcodes
 `STATUS:NEEDS-ACTION` and ignores priority/due — that goes away.
 
 The reverse status mapping is the inverse of the table above. Priority is
-mapped back through the §1 priority table (`p0`→0, `p1`→9, `p2`→5,
-`p3`→1). `due` is passed through unchanged (CalDAV expects an iCal
+mapped back through the §1 priority table (`p0`→1, `p1`→5, `p2`→9,
+`p3`→0). `due` is passed through unchanged (CalDAV expects an iCal
 datetime string; the haustoria does not reformat it).
 
 ### 4. Tests
@@ -256,7 +257,7 @@ datetime string; the haustoria does not reformat it).
 
 - `TestStatusValueRoundTrip` --- table-driven over the five VTODO STATUS values.
 - `TestPriorityValueRoundTrip` --- table-driven `p0`/`p1`/`p2`/`p3` ↔
-  `0`/`9`/`5`/`1`, plus out-of-band PRIORITY values (`2`, `3`, `7`) bucketed to
+  `1`/`5`/`9`/`0`, plus out-of-band PRIORITY values (`2`, `3`, `7`) bucketed to
   nearest.
 - `TestDuePassthrough` --- verbatim string passthrough.
 
@@ -286,7 +287,7 @@ datetime string; the haustoria does not reformat it).
   → `dodder show` displays `status=done` → `dodder organize` to set
   `status=todo` → checkout → CalDAV server has `STATUS:NEEDS-ACTION`.
 - Add `caldav_round_trip_priority_field`: VTODO with `PRIORITY:1` → checkin →
-  `priority=p3` → organize to `p1` → checkout → `PRIORITY:9`.
+  `priority=p0` → organize to `p2` → checkout → `PRIORITY:9`.
 - Add `caldav_round_trip_due_field`: passthrough verification.
 - Add `caldav_fresh_type_lookup`: re-commit the `!task` type with a new field
   definition between two `dodder status` runs; verify the haustoria picks up the
@@ -338,12 +339,12 @@ need to reach into the dormant index from `mike/haustoria_caldav`.
 
 Resolved in PR #100 review comments:
 
-1.  **Status enum values**: `todo` / `in-process` / `done` / `cancelled`. The
+1.  **Status enum values**: `todo` / `in_progress` / `done` / `cancelled`. The
     haustoria maps these to/from CalDAV STATUS values (table in §3).
 
-2.  **Priority**: enum with values `p0` / `p1` / `p2` / `p3` mapped to the
-    tasks.org convention (none / `!` / `!!` / `!!!`) and VTODO PRIORITY integers
-    `0` / `9` / `5` / `1` (table in §1).
+2.  **Priority**: enum with values `p0` / `p1` / `p2` / `p3` where `p0` is
+    highest. Maps to the tasks.org convention (`!!!` / `!!` / `!` / none)
+    and VTODO PRIORITY integers `1` / `5` / `9` / `0` (table in §1).
 
 3.  **`!chore`**: ships as a separate built-in type alongside `!task`, with the
     same field set. Future: explore an `!actionable` abstract type that both

--- a/docs/plans/2026-04-06-task-type-genesis-and-haustoria-fields.md
+++ b/docs/plans/2026-04-06-task-type-genesis-and-haustoria-fields.md
@@ -29,10 +29,14 @@ This plan does two things:
 - `!vtodo` as a persisted type (dropped --- haustoria-side only).
 - Langlang PEG grammars for any iCal property.
 - Generic interface mapping (`[implements.actionable.field-map]`).
-- `!chore` as a separate type. The existing `chores` calendar in
-  `~/workspaces/dodder-haustoria-caldav` will reuse `!task`.
+- An `!actionable` abstract type or any composition / inheritance mechanism
+  shared between `!task` and `!chore`. Both ship with duplicated field
+  lists; the abstract type is captured as future work in §1a.
 - Migration of existing repos. V14 → V15 was the only recent format bump and
   it's already shipped; this plan does not change persisted formats.
+- Conflict resolution between dodder-side edits and CalDAV-side edits
+  during sync. Last-write-wins for now; proper merge semantics block on
+  #19.
 
 ## Design
 
@@ -44,6 +48,7 @@ content:
 
 ``` toml
 file-extension = "toml"
+vim-syntax-type = "toml"
 
 [[fields]]
 name = "status"
@@ -55,15 +60,31 @@ default = "todo"
 name = "priority"
 kind = "enum"
 values = ["p0", "p1", "p2", "p3"]
+default = "p0"
 
 [[fields]]
 name = "due"
 kind = "string"
+
+[fields-reader]
+script = "yq -p toml -o json '{\"status\": .status, \"priority\": .priority, \"due\": .due}'"
+
+[fields-writer]
+script = "yq -p toml -o toml -i \".status = \\\"$DODDER_FIELD_status\\\" | .priority = \\\"$DODDER_FIELD_priority\\\" | .due = \\\"$DODDER_FIELD_due\\\"\" \"$DODDER_BLOB_PATH\""
 ```
 
-The blob format for `!task` instances is TOML (file extension `toml`); the
-fields are stored as TOML key/value pairs in the blob and as records in the
-binary stream index (see §3 for how the haustoria sets them).
+The blob format for `!task` instances is TOML. Each instance's blob mirrors the
+field values; the reader script projects them into `Metadata.Index.Fields` on
+every commit, and the writer script projects edits back into the blob during
+organize mutations.
+
+Both scripts are mandatory. PR #100 probes proved that omitting either breaks
+the round-trip: missing writer drops user edits and duplicates fields in
+`dodder show` (issue #102), and missing reader+writer means fields don't persist
+at all. See PR #100 commits `cfdb846` and `c5ebd34` for the full probe matrix.
+
+`yq` is required at runtime (it's already a dependency for the existing fields
+tests).
 
 Status enum values match the field-mutation work in `19c6f63` ("use 'done'
 instead of 'completed'"). The mapping to/from VTODO STATUS is the haustoria's
@@ -144,108 +165,90 @@ existing flag is reused.
 `echo/workspace_config_blobs`. Tommy codegen for the V2 workspace config is
 regenerated. The status-tag tests are deleted (see §4).
 
-**Look up the `!task` (or `!chore`) type blob digest fresh on every compile and
-decompile cycle.** Do NOT cache the digest at `Initialize`. The haustoria runs
-`s.supplies.ReadPrimitiveQuery` for `task:t` (or `chore:t`, keyed off
-`cal.TypeId`) inside `queryCheckedOutForCalendar` and `CheckoutOne`, captures
-the current type object's blob digest, and stamps it on each `fields.Field` it
-constructs. Rationale: the user might re-commit the type object with new field
-definitions; a cached digest would point at a stale blob and break field
-round-tripping for newly-set fields.
+#### Approach: blob-canonical, reader/writer-driven
 
-If the type is missing (e.g. the workspace was init'd without
-`-include-builtin-actionable-types` and no user-defined `!task` exists), the
-haustoria fails the query with a clear error pointing the user at
-`dodder init -include-builtin-actionable-types` or at creating the type
-manually.
+PR #100 probes (commits `cfdb846`, `c5ebd34`) established that the only
+reliable way to round-trip fields through the commit cycle is via the
+existing `[fields-reader]` / `[fields-writer]` script machinery declared on
+the type blob. The haustoria does NOT set `Metadata.Index.Fields` directly.
+Instead:
 
-#### Field-writer / field-reader interaction
+- **Compile path** (CalDAV → dodder): the haustoria builds a Go-side
+  `{status, priority, due}` from the parsed VTODO, serializes it as a TOML
+  blob, writes the blob to the blob store, and commits a `!task` object
+  whose blob digest points at it. The reader script declared on `!task`
+  (see §1) projects the fields out of the blob into
+  `Metadata.Index.Fields` automatically during commit.
 
-The fields plumbing in `papa/store/{field_writer,field_reader}.go` runs
-script-based projection between the blob and the index. Both functions
-early-return if the type blob has no `[fields-reader]` / `[fields-writer]`
-script configured (verified at `field_writer.go:110-112` and
-`field_reader.go:74-77`).
+- **User edits** (`dodder organize`): standard fields-writer pipeline.
+  Daughter has the edited field value, `tryWriteFields` runs the writer
+  script, the script rewrites the TOML blob, the new blob digest replaces
+  the old. `tryReadFields` re-projects the fields. Probe 12
+  (`field_full_task_organize_mutate_one_of_three`) confirms this round-trip.
 
-`!task` and `!chore` ship **without** reader/writer scripts. Consequence:
+- **Decompile path** (dodder → CalDAV): the haustoria reads
+  `Metadata.Index.Fields` (which the reader has populated from the blob)
+  for status / priority / due, applies the inverse mappings (table below),
+  and emits a VTODO via `CheckoutOne`.
 
-1.  The haustoria sets `daughter.Metadata.Index.Fields["status"]` (etc.) with
-    `TypeBlobDigest` populated.
-2.  The commit cycle calls `tryWriteFields` --- early-returns at
-    `fieldsWriter == nil`. Daughter fields stay intact.
-3.  The commit cycle calls `tryReadFields` --- early-returns at
-    `fieldsReader == nil`. Daughter fields still intact.
-4.  The binary stream-index encoder serializes `Metadata.Index.Fields` verbatim
-    (this is the codec change from `19c6f63`).
-5.  On read back, fields appear in the index without ever touching the blob.
+#### What this avoids vs the original draft
 
-The blob is therefore a **decorative artifact** for `!task` --- it can be empty
-or hold a TOML mirror of the fields, but neither dodder nor the haustoria reads
-it for field values. The canonical source is CalDAV (via the haustoria) and the
-cached projection is the binary stream index. **Open verification task:**
-confirm the binary codec actually persists `Metadata.Index.Fields` even when no
-script ran (the codec was added in `19c6f63` and tests pass for organize-driven
-mutation, so this should hold, but the haustoria path is a new entry point and
-warrants a unit test before relying on it).
+- **No fresh `TypeBlobDigest` lookup needed.** The reader script handles
+  digest stamping automatically when it runs during commit.
+- **No new code paths in `papa/store`.** The existing reader/writer
+  machinery does all the work.
+- **No `s.supplies.ReadPrimitiveQuery` plumbing.** The haustoria doesn't
+  need to know the type blob digest at all.
+- **`dodder` is a source of truth between sync cycles.** User edits via
+  organize survive haustoria re-syncs because the dodder blob has the
+  canonical field values. Conflict resolution between dodder and CalDAV
+  is out of scope for this PR (last-write-wins is acceptable until #19
+  lands).
 
-**Compile path (`queryCheckedOutForCalendar`)**: replace the `StatusTags` block
-with direct field projection. The type blob digest is fetched fresh per calendar
-(the result can be reused for all tasks in the same calendar because the type
-object can't change mid-query).
+#### Compile path: VTODO → TOML blob
 
-``` go
-typeBlobDigest, err := s.lookupTypeBlobDigest(cal.TypeId) // fresh per calendar
-if err != nil {
-    return errors.Wrapf(err, "lookup %s type blob", cal.TypeId)
+```go
+// per task in queryCheckedOutForCalendar
+blob := buildTaskTomlBlob(twm.Task)
+if err := s.writeBlob(external, blob); err != nil {
+    return errors.Wrapf(err, "write task blob for %s", twm.Task.UID)
 }
-
-// ... per task ...
-
-metadata := external.GetMetadataMutable()
-indexFields := metadata.GetIndexMutable().GetFieldsMutable()
-
-indexFields.Add(fields.Field{
-    Key:            "status",
-    Value:          mapVTODOStatusToFieldValue(twm.Task.Status), // "todo" default
-    TypeBlobDigest: typeBlobDigest,
-})
-
-indexFields.Add(fields.Field{
-    Key:            "priority",
-    Value:          mapVTODOPriorityToFieldValue(twm.Task.Priority), // "p0" default
-    TypeBlobDigest: typeBlobDigest,
-})
-
-if twm.Task.Due != "" {
-    indexFields.Add(fields.Field{
-        Key:            "due",
-        Value:          twm.Task.Due,
-        TypeBlobDigest: typeBlobDigest,
-    })
-}
+// reader script runs during commit and projects fields into the index
 ```
 
-The status value mapping:
+`buildTaskTomlBlob` is a small Go function that emits TOML like:
 
-  VTODO STATUS     `!task` field value
-  ---------------- ---------------------
-  (absent)         `todo`
-  `NEEDS-ACTION`   `todo`
-  `IN-PROCESS`     `in-process`
-  `COMPLETED`      `done`
-  `CANCELLED`      `cancelled`
+```toml
+status = "in-process"
+priority = "p2"
+due = "20260415T120000Z"
+```
+
+The status and priority values come from the mapping tables below.
+
+#### Status mapping
+
+| VTODO STATUS   | `!task` field value |
+|----------------|---------------------|
+| (absent)       | `todo`              |
+| `NEEDS-ACTION` | `todo`              |
+| `IN-PROCESS`   | `in-process`        |
+| `COMPLETED`    | `done`              |
+| `CANCELLED`    | `cancelled`         |
 
 Unknown values fall back to `todo` and log a warning at debug level.
 
-**Decompile path (`CheckoutOne`)**: pull the same fields out of
-`object.GetMetadata().GetIndex().GetFields()` and write them onto the
-`caldav.Task` before PUT. Currently `CheckoutOne` doesn't read fields at all and
-the existing decompile hardcodes `STATUS:NEEDS-ACTION`.
+#### Decompile path: `Metadata.Index.Fields` → VTODO
 
-The reverse status mapping is the inverse of the table above. `priority` is
-mapped back through the §1 priority table (`p0`→0, `p1`→9, `p2`→5, `p3`→1).
-`due` is passed through unchanged (CalDAV expects an iCal datetime string; we
-don't reformat it).
+`CheckoutOne` reads the three fields out of
+`object.GetMetadata().GetIndex().GetFields()`, applies the inverse status
+and priority mappings, and emits a VTODO. The current decompile hardcodes
+`STATUS:NEEDS-ACTION` and ignores priority/due — that goes away.
+
+The reverse status mapping is the inverse of the table above. Priority is
+mapped back through the §1 priority table (`p0`→0, `p1`→9, `p2`→5,
+`p3`→1). `due` is passed through unchanged (CalDAV expects an iCal
+datetime string; the haustoria does not reformat it).
 
 ### 4. Tests
 
@@ -257,15 +260,22 @@ don't reformat it).
   nearest.
 - `TestDuePassthrough` --- verbatim string passthrough.
 
-**Critical-path Go test** (must run before BATS):
+**Already-landed probe tests** (PR #100, `cfdb846` and `c5ebd34`,
+`zz-tests_bats/current_version/fields.bats`):
 
-- `TestFieldsPersistThroughCommitWithoutScripts` --- in
-  `papa/store/field_writer_test.go` (or a new `field_persistence_test.go`).
-  Commits a daughter object with `Metadata.Index.Fields` populated but no
-  `[fields-writer]` / `[fields-reader]` scripts on the type blob. Reads the
-  object back from the stream index and asserts the fields survived. This
-  validates the assumption documented in §3 "Field-writer / field-reader
-  interaction" before the haustoria starts depending on it.
+- `field_persists_without_any_scripts` — confirms fields are dropped when
+  the type has no scripts. Filed as issue #101 for follow-up.
+- `field_persists_with_reader_only_no_writer` — confirms reader-only mode
+  drops user edits and duplicates fields in `show` output. Filed as
+  issue #102.
+- `field_full_task_three_fields_from_blob` — confirms the haustoria
+  compile path works: TOML blob with three fields baked in projects all
+  three via the reader script.
+- `field_full_task_organize_mutate_one_of_three` — confirms
+  organize-driven field mutation round-trips through the writer script
+  while preserving untouched fields.
+- `field_full_task_organize_from_empty_blob` — documents the empty-blob
+  failure mode (also issue #101).
 
 **BATS integration tests** in `zz-tests_bats/current_version/`:
 
@@ -354,49 +364,63 @@ Resolved in PR #100 review comments:
     haustoria flow (the canonical source is CalDAV); for direct
     `dodder new !task` use, the user edits a TOML file.
 
-## Open verification before implementation
+## Resolved verification (PR #100 probes)
 
-1.  **Field codec round-trip without scripts**: `!task` ships without
-    `[fields-reader]` / `[fields-writer]` script configs. The plan assumes that
-    fields set directly on `Metadata.Index.Fields` (with TypeBlobDigest
-    populated) are persisted by the binary stream-index codec from `19c6f63` and
-    read back intact on the next query. Confirmed by reading
-    `field_writer.go:110-112` and `field_reader.go:74-77` (both early-return
-    when no script is configured), but the assumption is gated on a Go unit test
-    (`TestFieldsPersistThroughCommitWithoutScripts`, see §4) that runs BEFORE
-    any haustoria changes.
+The original draft assumed fields could be set directly on
+`Metadata.Index.Fields` and would persist via the binary stream-index codec
+without scripts. **PR #100 probes proved that wrong** — see the five
+`field_*` probe tests in `zz-tests_bats/current_version/fields.bats` landed
+in commits `cfdb846` and `c5ebd34`.
 
-2.  **`s.supplies.ReadPrimitiveQuery` for type lookup**: confirm the primitive
-    query API can find a type object by `task:t` predicate from inside the
-    haustoria. If not, exposing a small accessor on the supplies struct
-    (e.g. `GetBuiltinTypeBlobDigest("!task")`).
+Both `tryWriteFields` and `tryReadFields` early-return on missing scripts,
+but the daughter fields do NOT survive the early-return path through to the
+binary codec — they are silently dropped at commit time.
+
+The plan now uses `[fields-reader]` + `[fields-writer]` scripts on `!task`
+(see §1) so the haustoria can rely on the existing fields machinery instead
+of bypassing it. The previously-required
+`TestFieldsPersistThroughCommitWithoutScripts` is unnecessary; probes 11 and
+12 already cover the supported flow.
+
+Two follow-up bugs were filed against the fields infrastructure:
+
+- **#101** — `fields-writer` should support blob-less first writes. The
+  haustoria sidesteps this by always writing a non-empty TOML blob; the bug
+  remains worth fixing for future programmatic field-set callers.
+- **#102** — reader-only mode silently drops user edits AND duplicates fields
+  in `show` output. Independent of this PR but exposed by the probes.
 
 ## Implementation order
 
-1.  Land `TestFieldsPersistThroughCommitWithoutScripts` first --- validates the
-    core assumption before any haustoria work.
-2.  Add `type_blobs.DefaultTaskType()` + `DefaultChoreType()` + unit tests.
-3.  Wire `prepareBuiltinActionableTypes` into `local_working_copy/genesis.go`
+1.  Add `type_blobs.DefaultTaskType()` + `DefaultChoreType()` (with the
+    reader and writer scripts from §1) + unit tests.
+2.  Wire `prepareBuiltinActionableTypes` into `local_working_copy/genesis.go`
     and add the `BigBang.IncludeBuiltinActionableTypes` flag.
-4.  Add `genesis_opt_in_actionable_types` BATS test for the genesis path.
-5.  Update `mike/haustoria_caldav`: fresh-lookup helper, drop `StatusTags`,
-    compile path field projection. Drop `StatusTags` from
-    `echo/workspace_config_blobs` config (regenerate tommy codegen).
-6.  Update `mike/haustoria_caldav` decompile path: read fields from metadata,
-    write to VTODO.
-7.  Add Go round-trip tests + BATS round-trip tests.
-8.  Drop existing `caldav_status_tags_*` tests.
-9.  Update FDR-0007 status and add the supersede note to the !vtodo plan.
-10. Test the live workspace, re-init with the new flag.
+3.  Add `genesis_opt_in_actionable_types` BATS test for the genesis path.
+4.  Update `mike/haustoria_caldav` compile path: drop `StatusTags`, build
+    TOML blob from VTODO via `buildTaskTomlBlob`, write to blob store, commit
+    with the blob digest. Drop `StatusTags` from `echo/workspace_config_blobs`
+    config (regenerate tommy codegen).
+5.  Update `mike/haustoria_caldav` decompile path: read fields from
+    `Metadata.Index.Fields`, apply inverse mappings, write to VTODO.
+6.  Add Go round-trip tests + BATS round-trip tests.
+7.  Drop existing `caldav_status_tags_*` tests.
+8.  Update FDR-0007 status and add the supersede note to the !vtodo plan.
+9.  Test the live workspace, re-init with the new flag.
 
 ## Risks
 
-- **Field codec assumption**: if `TestFieldsPersistThroughCommitWithoutScripts`
-  fails, the whole approach needs rethinking --- either ship a `fields-writer`
-  script for `!task` (a small TOML projector), or add a "field-only" commit path
-  that bypasses the script gate. The test runs first to surface this fast.
+- **`yq` runtime dependency**: the reader/writer scripts shell out to `yq`
+  on every commit. Already a dependency for the existing fields tests, so
+  no new external requirement, but worth noting that `!task` won't work in
+  environments without it. Three OS process invocations per object on
+  commit (writer + reader, plus reader on subsequent reads). For 1100-task
+  workspaces this is a few thousand `yq` invocations on a full sync —
+  acceptable for an interactive command, possibly slow enough to want
+  batching later.
 
-- **Field digest drift**: even with fresh lookup, if the user re-commits the
+- **Field digest drift**: even with the reader script auto-stamping the
+  current type blob digest, if the user re-commits the
   `!task` type with incompatible field defs (say removing the `status` field),
   existing index records will have a stale `TypeBlobDigest` and may not resolve
   correctly on read. Same risk class as user-defined types --- no new

--- a/docs/plans/2026-04-06-task-type-genesis-and-haustoria-fields.md
+++ b/docs/plans/2026-04-06-task-type-genesis-and-haustoria-fields.md
@@ -38,12 +38,12 @@ This plan does two things:
 
 ### 1. `!task` type blob
 
-`golf/type_blobs/main.go` gains a `DefaultTaskType()` function returning a
-`TomlV2` with the following content:
+`golf/type_blobs/main.go` gains a `DefaultTaskType()` function (and a sibling
+`DefaultChoreType()` --- see §1a) returning a `TomlV2` with the following
+content:
 
 ``` toml
-file-extension = "task"
-vim-syntax-type = "taskpaper"
+file-extension = "toml"
 
 [[fields]]
 name = "status"
@@ -53,51 +53,87 @@ default = "todo"
 
 [[fields]]
 name = "priority"
-kind = "u32"
+kind = "enum"
+values = ["p0", "p1", "p2", "p3"]
 
 [[fields]]
 name = "due"
 kind = "string"
 ```
 
+The blob format for `!task` instances is TOML (file extension `toml`); the
+fields are stored as TOML key/value pairs in the blob and as records in the
+binary stream index (see §3 for how the haustoria sets them).
+
 Status enum values match the field-mutation work in `19c6f63` ("use 'done'
-instead of 'completed' in task status enum values"). The mapping to/from VTODO
-STATUS is the haustoria's job (see §3 below).
+instead of 'completed'"). The mapping to/from VTODO STATUS is the haustoria's
+job (see §3 below).
 
-Open question --- see "Decisions to confirm" --- whether the file extension
-should be `task`, `taskpaper`, or omitted.
+`priority` is an enum with values `p0` / `p1` / `p2` / `p3` corresponding to the
+tasks.org convention (none / `!` / `!!` / `!!!`). The numeric VTODO PRIORITY
+mapping is the haustoria's job:
 
-### 2. Genesis: commit `!task` alongside `!md`
+  VTODO PRIORITY   `!task` priority   tasks.org
+  ---------------- ------------------ -----------
+  0 (or absent)    `p0`               (none)
+  9                `p1`               `!`
+  5                `p2`               `!!`
+  1                `p3`               `!!!`
 
-`local_working_copy/genesis.go` gains a sibling helper next to
+Other PRIORITY values fall back to the closest bucket on read; on write the
+haustoria emits the canonical numeric value above.
+
+### 1a. `!chore` type blob
+
+`!chore` ships as a separate built-in type with the **same field set** as
+`!task`. There is no inheritance / mixin mechanism in dodder yet --- the field
+list is duplicated in both `DefaultTaskType()` and `DefaultChoreType()`. Future
+work: explore an `!actionable` abstract type that both `!task` and `!chore`
+compose against, replacing the duplication.
+
+The reason both ship together: the live workspace already has separate `tasks`
+and `chores` calendars with semantically distinct meanings (one-shot work vs
+recurring habits), and CalDAV doesn't carry that distinction in any field.
+Calendar-to-type binding stays a workspace config concern.
+
+### 2. Genesis: opt-in `!task` and `!chore` built-in types
+
+`local_working_copy/genesis.go` gains a single helper next to
 `prepareDefaultType`:
 
 ``` go
-func (local *Repo) prepareTaskType(
+func (local *Repo) prepareBuiltinActionableTypes(
     bigBang env_repo.BigBang,
     builder *import_plan.Builder,
-) (objectIdType ids.TypeStruct, blobDigest domain_interfaces.MarklId, err error)
+) (err error)
 ```
 
 Behavior:
 
-- Allocates an `id.TypeStruct` for `task`.
-- Calls `type_blobs.DefaultTaskType()` to get the blob.
-- Saves the blob via the typed blob store, capturing the digest.
-- Constructs a `sku.Transacted` for the type object, sets its blob digest and
-  type (`!toml-type-v2`), and adds it to the import plan builder.
-- Returns the captured blob digest so the haustoria can stamp it on `Field`
-  records (see §3).
+- For each of `!task` and `!chore`:
+  - Allocates the `id.TypeStruct`.
+  - Calls the corresponding `type_blobs.DefaultTaskType()` /
+    `DefaultChoreType()` constructor.
+  - Saves the blob via the typed blob store.
+  - Constructs a `sku.Transacted` for the type object, sets its blob digest and
+    type (`!toml-type-v2`), and adds it to the import plan builder.
+- Does **not** return digests; the haustoria looks them up fresh on each commit
+  cycle (see §3).
 
-`initDefaultTypeAndConfig` calls both `prepareDefaultType` and
-`prepareTaskType`. The `!task` blob digest is stored on the `Repo` (or fetched
-on demand via a query) so the haustoria initialization step can find it.
+**Opt-in via a new `BigBang.IncludeBuiltinActionableTypes` flag.** Default is
+`false` --- `dodder init` does NOT commit `!task` / `!chore` unless the user
+passes the flag. Once the types stabilize and the haustoria flow is proven, the
+flag can flip to opt-out (or merge into `ExcludeDefaultType`), but for the
+bootstrap phase the existing default-type semantics stay unchanged.
 
-The new step is gated on the existing `BigBang.ExcludeDefaultType` flag --- same
-flag that already gates `!md`. This means `init-workspace` and `clone` both skip
-it, which matches existing behavior for default types.
+Rationale for opt-in: the existing `dodder init` test fleet, fixture generation,
+and downstream tooling all assume the only built-in type is `!md`. Opt-in keeps
+this PR's blast radius minimal --- only fresh repos that explicitly request
+actionable types pay the fixture-regeneration and behavior-change cost. The live
+haustoria workspace will be one of the first opt-in users.
 
-No new `BigBang` field is added.
+The flag is exposed on the genesis command (and madder's init for now). No
+existing flag is reused.
 
 ### 3. Haustoria: VTODO ↔ `!task` field mapping
 
@@ -108,41 +144,83 @@ No new `BigBang` field is added.
 `echo/workspace_config_blobs`. Tommy codegen for the V2 workspace config is
 regenerated. The status-tag tests are deleted (see §4).
 
-**Add a `taskTypeBlobDigest` lookup on `Initialize`.** When `s.supplies` is set,
-the haustoria does a one-shot
-`s.supplies.ReadPrimitiveQuery(taskTypeQuery, ...)` to find the committed
-`!task` type object and caches its blob digest. If the type is missing
-(workspace, cloned repo with `ExcludeDefaultType`), the haustoria returns an
-init error pointing the user at the missing builtin --- the workspace mode isn't
-expected to host a CalDAV haustoria anyway.
+**Look up the `!task` (or `!chore`) type blob digest fresh on every compile and
+decompile cycle.** Do NOT cache the digest at `Initialize`. The haustoria runs
+`s.supplies.ReadPrimitiveQuery` for `task:t` (or `chore:t`, keyed off
+`cal.TypeId`) inside `queryCheckedOutForCalendar` and `CheckoutOne`, captures
+the current type object's blob digest, and stamps it on each `fields.Field` it
+constructs. Rationale: the user might re-commit the type object with new field
+definitions; a cached digest would point at a stale blob and break field
+round-tripping for newly-set fields.
+
+If the type is missing (e.g. the workspace was init'd without
+`-include-builtin-actionable-types` and no user-defined `!task` exists), the
+haustoria fails the query with a clear error pointing the user at
+`dodder init -include-builtin-actionable-types` or at creating the type
+manually.
+
+#### Field-writer / field-reader interaction
+
+The fields plumbing in `papa/store/{field_writer,field_reader}.go` runs
+script-based projection between the blob and the index. Both functions
+early-return if the type blob has no `[fields-reader]` / `[fields-writer]`
+script configured (verified at `field_writer.go:110-112` and
+`field_reader.go:74-77`).
+
+`!task` and `!chore` ship **without** reader/writer scripts. Consequence:
+
+1.  The haustoria sets `daughter.Metadata.Index.Fields["status"]` (etc.) with
+    `TypeBlobDigest` populated.
+2.  The commit cycle calls `tryWriteFields` --- early-returns at
+    `fieldsWriter == nil`. Daughter fields stay intact.
+3.  The commit cycle calls `tryReadFields` --- early-returns at
+    `fieldsReader == nil`. Daughter fields still intact.
+4.  The binary stream-index encoder serializes `Metadata.Index.Fields` verbatim
+    (this is the codec change from `19c6f63`).
+5.  On read back, fields appear in the index without ever touching the blob.
+
+The blob is therefore a **decorative artifact** for `!task` --- it can be empty
+or hold a TOML mirror of the fields, but neither dodder nor the haustoria reads
+it for field values. The canonical source is CalDAV (via the haustoria) and the
+cached projection is the binary stream index. **Open verification task:**
+confirm the binary codec actually persists `Metadata.Index.Fields` even when no
+script ran (the codec was added in `19c6f63` and tests pass for organize-driven
+mutation, so this should hold, but the haustoria path is a new entry point and
+warrants a unit test before relying on it).
 
 **Compile path (`queryCheckedOutForCalendar`)**: replace the `StatusTags` block
-with direct field projection.
+with direct field projection. The type blob digest is fetched fresh per calendar
+(the result can be reused for all tasks in the same calendar because the type
+object can't change mid-query).
 
 ``` go
+typeBlobDigest, err := s.lookupTypeBlobDigest(cal.TypeId) // fresh per calendar
+if err != nil {
+    return errors.Wrapf(err, "lookup %s type blob", cal.TypeId)
+}
+
+// ... per task ...
+
 metadata := external.GetMetadataMutable()
 indexFields := metadata.GetIndexMutable().GetFieldsMutable()
 
-statusValue := mapVTODOStatusToFieldValue(twm.Task.Status) // "todo" default
 indexFields.Add(fields.Field{
     Key:            "status",
-    Value:          statusValue,
-    TypeBlobDigest: s.taskTypeBlobDigest,
+    Value:          mapVTODOStatusToFieldValue(twm.Task.Status), // "todo" default
+    TypeBlobDigest: typeBlobDigest,
 })
 
-if twm.Task.Priority != 0 {
-    indexFields.Add(fields.Field{
-        Key:            "priority",
-        Value:          strconv.Itoa(twm.Task.Priority),
-        TypeBlobDigest: s.taskTypeBlobDigest,
-    })
-}
+indexFields.Add(fields.Field{
+    Key:            "priority",
+    Value:          mapVTODOPriorityToFieldValue(twm.Task.Priority), // "p0" default
+    TypeBlobDigest: typeBlobDigest,
+})
 
 if twm.Task.Due != "" {
     indexFields.Add(fields.Field{
         Key:            "due",
         Value:          twm.Task.Due,
-        TypeBlobDigest: s.taskTypeBlobDigest,
+        TypeBlobDigest: typeBlobDigest,
     })
 }
 ```
@@ -165,16 +243,29 @@ Unknown values fall back to `todo` and log a warning at debug level.
 the existing decompile hardcodes `STATUS:NEEDS-ACTION`.
 
 The reverse status mapping is the inverse of the table above. `priority` is
-parsed back to `int`. `due` is passed through unchanged (CalDAV expects an iCal
-datetime string; we don't reformat it).
+mapped back through the §1 priority table (`p0`→0, `p1`→9, `p2`→5, `p3`→1).
+`due` is passed through unchanged (CalDAV expects an iCal datetime string; we
+don't reformat it).
 
 ### 4. Tests
 
 **Unit tests (Go)** for the haustoria:
 
 - `TestStatusValueRoundTrip` --- table-driven over the five VTODO STATUS values.
-- `TestPriorityRoundTrip` --- `0`, `1`, `5`, `9`.
+- `TestPriorityValueRoundTrip` --- table-driven `p0`/`p1`/`p2`/`p3` ↔
+  `0`/`9`/`5`/`1`, plus out-of-band PRIORITY values (`2`, `3`, `7`) bucketed to
+  nearest.
 - `TestDuePassthrough` --- verbatim string passthrough.
+
+**Critical-path Go test** (must run before BATS):
+
+- `TestFieldsPersistThroughCommitWithoutScripts` --- in
+  `papa/store/field_writer_test.go` (or a new `field_persistence_test.go`).
+  Commits a daughter object with `Metadata.Index.Fields` populated but no
+  `[fields-writer]` / `[fields-reader]` scripts on the type blob. Reads the
+  object back from the stream index and asserts the fields survived. This
+  validates the assumption documented in §3 "Field-writer / field-reader
+  interaction" before the haustoria starts depending on it.
 
 **BATS integration tests** in `zz-tests_bats/current_version/`:
 
@@ -184,30 +275,42 @@ datetime string; we don't reformat it).
 - Add `caldav_round_trip_status_field`: VTODO with `STATUS:COMPLETED` → checkin
   → `dodder show` displays `status=done` → `dodder organize` to set
   `status=todo` → checkout → CalDAV server has `STATUS:NEEDS-ACTION`.
-- Add `caldav_priority_and_due_round_trip`: same but for the other two fields.
-- Add `genesis_includes_task_type`: fresh `dodder init` then
-  `dodder show '!task:t'` produces a non-empty result with the field definitions
-  visible.
+- Add `caldav_round_trip_priority_field`: VTODO with `PRIORITY:1` → checkin →
+  `priority=p3` → organize to `p1` → checkout → `PRIORITY:9`.
+- Add `caldav_round_trip_due_field`: passthrough verification.
+- Add `caldav_fresh_type_lookup`: re-commit the `!task` type with a new field
+  definition between two `dodder status` runs; verify the haustoria picks up the
+  new digest fresh on the second run.
+- Add `genesis_opt_in_actionable_types`: fresh
+  `dodder init -include-builtin-actionable-types` then `dodder show '!task:t'`
+  and `dodder show '!chore:t'` both return non-empty results with the field
+  definitions visible. Without the flag, both return empty.
 
-**Fixture regeneration**: `dodder show :t` on a fresh-store BATS test will now
-include `!task` alongside `!md`. Run `just test-bats-update-fixtures` and commit
-the new `current_version` fixtures + `.fixtures.env`. The frozen v14 snapshot
-stays untouched.
+**Fixture regeneration**: only the new opt-in genesis test creates a repo with
+`!task`/`!chore` --- the existing fresh-store fixtures stay unchanged because
+the default is opt-out. The opt-in path gets its own `.fixtures.env` entries.
+The frozen v14 snapshot stays untouched.
 
 ### 5. Live workspace migration (`~/workspaces/dodder-haustoria-caldav`)
 
-After the PR merges, the live workspace needs:
+The existing workspace is at store V14 with no zettels checked in. The cleanest
+path is to **re-init the repo** with the new opt-in flag rather than
+retrofitting:
 
-1.  Edit `workspace/.dodder-workspace`: remove the three
-    `[haustoria.calendars.*.status-tags]` blocks. (No replacement --- fields are
-    projected unconditionally now.)
-2.  The repo is at store V14, code at V15. No format migration is needed; V14
-    reads fine on V15. Existing zettels (zero, in this case) keep working.
-3.  `dodder status` should now show field columns (`status=todo` /
-    `status=done`) on each untracked CalDAV resource.
-4.  The dormant filtering issue noted in the project memory becomes moot:
-    `dodder status '^status=done'` filters completed tasks at the doddish layer,
-    no need to reach into the dormant index from `mike/haustoria_caldav`.
+1.  Back up `workspace/.dodder-workspace` (the haustoria config block is the
+    only thing worth keeping).
+2.  Wipe `~/workspaces/dodder-haustoria-caldav/.dodder/`.
+3.  Re-run `dodder init -include-builtin-actionable-types` against the parent
+    dir.
+4.  Restore the workspace config, removing the three
+    `[haustoria.calendars.*.status-tags]` blocks (no replacement --- fields are
+    projected automatically).
+5.  `dodder status` should show field columns (`status=todo` / `status=done`,
+    `priority=p0`...`p3`) on each untracked CalDAV resource.
+
+The dormant filtering issue noted in the project memory becomes moot:
+`dodder status '^status=done'` filters completed tasks at the doddish layer, no
+need to reach into the dormant index from `mike/haustoria_caldav`.
 
 ### 6. Docs
 
@@ -221,54 +324,83 @@ After the PR merges, the live workspace needs:
 - No new FDR for the `!task` type itself --- it's a built-in, not a feature.
   Mention it in the FDR-0007 update instead.
 
-## Decisions to confirm
+## Decisions (resolved from review)
 
-These are open until you comment on this file:
+Resolved in PR #100 review comments:
 
-1.  **Status enum values**: `todo` / `in-process` / `done` / `cancelled`
-    (matches the field-mutation work in `19c6f63`). Alternative: keep VTODO
-    casing (`needs-action` / `in-process` / `completed` / `cancelled`).
+1.  **Status enum values**: `todo` / `in-process` / `done` / `cancelled`. The
+    haustoria maps these to/from CalDAV STATUS values (table in §3).
 
-2.  **`!chore` handling**: drop `!chore` entirely and have both `tasks` and
-    `chores` calendars use `!task`. Alternative: ship `!task` and `!chore` as
-    two separate built-in types with the same field set.
+2.  **Priority**: enum with values `p0` / `p1` / `p2` / `p3` mapped to the
+    tasks.org convention (none / `!` / `!!` / `!!!`) and VTODO PRIORITY integers
+    `0` / `9` / `5` / `1` (table in §1).
 
-3.  **`ExcludeDefaultType` semantics**: gate `!task` under the existing flag
-    alongside `!md`. Alternative: separate `ExcludeDefaultTaskType` flag.
+3.  **`!chore`**: ships as a separate built-in type alongside `!task`, with the
+    same field set. Future: explore an `!actionable` abstract type that both
+    `!task` and `!chore` compose against (less inheritance, more composition).
 
-4.  **`StatusTags` removal**: drop the field, the config key, and the tests in
-    one PR. Alternative: leave as a deprecated no-op for one release.
+4.  **Genesis flag**: new `BigBang.IncludeBuiltinActionableTypes`, default
+    `false`. Opt-in for now; can flip to opt-out once the types stabilize. No
+    reuse of `ExcludeDefaultType`.
 
-5.  **`TypeBlobDigest` discovery**: one-shot `s.supplies.ReadPrimitiveQuery`
-    lookup on `Initialize`. Alternative: explicit accessor on the
-    `store_workspace.Supplies` struct
+5.  **`StatusTags` removal**: drop the field, the config keys, and the tests in
+    one PR. The live workspace is the only consumer.
+
+6.  **`TypeBlobDigest` discovery**: fresh lookup on every compile and decompile
+    cycle (per calendar, not per task). No caching.
+
+7.  **File extension on `!task` / `!chore`**: `toml`. Instances are stored as
+    TOML blobs that mirror the field values. The blob is decorative for the
+    haustoria flow (the canonical source is CalDAV); for direct
+    `dodder new !task` use, the user edits a TOML file.
+
+## Open verification before implementation
+
+1.  **Field codec round-trip without scripts**: `!task` ships without
+    `[fields-reader]` / `[fields-writer]` script configs. The plan assumes that
+    fields set directly on `Metadata.Index.Fields` (with TypeBlobDigest
+    populated) are persisted by the binary stream-index codec from `19c6f63` and
+    read back intact on the next query. Confirmed by reading
+    `field_writer.go:110-112` and `field_reader.go:74-77` (both early-return
+    when no script is configured), but the assumption is gated on a Go unit test
+    (`TestFieldsPersistThroughCommitWithoutScripts`, see §4) that runs BEFORE
+    any haustoria changes.
+
+2.  **`s.supplies.ReadPrimitiveQuery` for type lookup**: confirm the primitive
+    query API can find a type object by `task:t` predicate from inside the
+    haustoria. If not, exposing a small accessor on the supplies struct
     (e.g. `GetBuiltinTypeBlobDigest("!task")`).
-
-6.  **File extension on `!task`**: `task`, `taskpaper`, or omitted. The blob
-    isn't used for anything (the haustoria reads VTODOs from CalDAV, not from
-    files), so the extension only affects edit/checkout fallback paths.
 
 ## Implementation order
 
-1.  Add `type_blobs.DefaultTaskType()` + unit test.
-2.  Wire `prepareTaskType` into `local_working_copy/genesis.go`.
-3.  Run `just test-bats-update-fixtures`, review and commit fixture diff.
-4.  Update `mike/haustoria_caldav` compile path: drop `StatusTags`, add field
-    projection. Drop `StatusTags` from `echo/workspace_config_blobs` config.
-5.  Update `mike/haustoria_caldav` decompile path: read fields from metadata,
+1.  Land `TestFieldsPersistThroughCommitWithoutScripts` first --- validates the
+    core assumption before any haustoria work.
+2.  Add `type_blobs.DefaultTaskType()` + `DefaultChoreType()` + unit tests.
+3.  Wire `prepareBuiltinActionableTypes` into `local_working_copy/genesis.go`
+    and add the `BigBang.IncludeBuiltinActionableTypes` flag.
+4.  Add `genesis_opt_in_actionable_types` BATS test for the genesis path.
+5.  Update `mike/haustoria_caldav`: fresh-lookup helper, drop `StatusTags`,
+    compile path field projection. Drop `StatusTags` from
+    `echo/workspace_config_blobs` config (regenerate tommy codegen).
+6.  Update `mike/haustoria_caldav` decompile path: read fields from metadata,
     write to VTODO.
-6.  Update / add BATS tests in `zz-tests_bats/current_version/`.
-7.  Update FDR-0007 status and add the supersede note to the !vtodo plan.
-8.  Test the live workspace, update its `.dodder-workspace`.
+7.  Add Go round-trip tests + BATS round-trip tests.
+8.  Drop existing `caldav_status_tags_*` tests.
+9.  Update FDR-0007 status and add the supersede note to the !vtodo plan.
+10. Test the live workspace, re-init with the new flag.
 
 ## Risks
 
-- **Field digest binding**: if the genesis-committed `!task` type blob digest
-  drifts (e.g. someone changes `DefaultTaskType()` after the first commit on a
-  given repo), existing field records on already-checked-in objects will have a
-  stale `TypeBlobDigest`. This is the same risk that already exists for
-  user-defined types and the field round-trip via organize, so no new mitigation
-  is needed --- but worth noting in the FDR.
+- **Field codec assumption**: if `TestFieldsPersistThroughCommitWithoutScripts`
+  fails, the whole approach needs rethinking --- either ship a `fields-writer`
+  script for `!task` (a small TOML projector), or add a "field-only" commit path
+  that bypasses the script gate. The test runs first to surface this fast.
+
+- **Field digest drift**: even with fresh lookup, if the user re-commits the
+  `!task` type with incompatible field defs (say removing the `status` field),
+  existing index records will have a stale `TypeBlobDigest` and may not resolve
+  correctly on read. Same risk class as user-defined types --- no new
+  mitigation, but worth a note in the FDR.
 
 - **Workspace status output churn**: every BATS test that does `dodder status`
   in a haustoria workspace will now show field columns. The two-pass WRONG

--- a/docs/plans/2026-04-06-task-type-genesis-and-haustoria-fields.md
+++ b/docs/plans/2026-04-06-task-type-genesis-and-haustoria-fields.md
@@ -1,0 +1,281 @@
+# `!task` type at genesis + haustoria-side VTODO field mapping
+
+## Context
+
+The fields infrastructure (mild-elm branch) is complete: type blobs declare
+`[[fields]]` entries, fields are projected on commit, persisted in the binary
+codec, queryable via doddish, and mutable via organize. The CalDAV haustoria
+currently handles VTODO `STATUS` as a lossy `status-tags` config mapping that
+projects status into a *tag*; `PRIORITY` and `DUE` are dropped entirely.
+
+The previous design (`docs/plans/2026-04-05-vtodo-langlang-design.md`) proposed
+adding `!vtodo` as a persisted type with a langlang PEG grammar to extract
+fields from a raw VTODO blob. **That plan is dropped.** VTODO format is a
+haustoria-side concern, not a repo-side concern. The CalDAV haustoria already
+parses VTODOs natively (`hotel/caldav/parser.go`); it can populate `!task`
+fields directly without round-tripping through a PEG grammar or persisting any
+iCal-shaped type.
+
+This plan does two things:
+
+1.  Formally commit a `!task` type into the bigbang/genesis process so every
+    fresh repo has it as a built-in.
+2.  Hardcode the VTODO ↔ `!task` field mapping inside `mike/haustoria_caldav` so
+    `status`, `priority`, and `due` round-trip as typed fields instead of as a
+    lossy `zz-archive-task-done` tag.
+
+## Out of Scope
+
+- `!vtodo` as a persisted type (dropped --- haustoria-side only).
+- Langlang PEG grammars for any iCal property.
+- Generic interface mapping (`[implements.actionable.field-map]`).
+- `!chore` as a separate type. The existing `chores` calendar in
+  `~/workspaces/dodder-haustoria-caldav` will reuse `!task`.
+- Migration of existing repos. V14 → V15 was the only recent format bump and
+  it's already shipped; this plan does not change persisted formats.
+
+## Design
+
+### 1. `!task` type blob
+
+`golf/type_blobs/main.go` gains a `DefaultTaskType()` function returning a
+`TomlV2` with the following content:
+
+``` toml
+file-extension = "task"
+vim-syntax-type = "taskpaper"
+
+[[fields]]
+name = "status"
+kind = "enum"
+values = ["todo", "in-process", "done", "cancelled"]
+default = "todo"
+
+[[fields]]
+name = "priority"
+kind = "u32"
+
+[[fields]]
+name = "due"
+kind = "string"
+```
+
+Status enum values match the field-mutation work in `19c6f63` ("use 'done'
+instead of 'completed' in task status enum values"). The mapping to/from VTODO
+STATUS is the haustoria's job (see §3 below).
+
+Open question --- see "Decisions to confirm" --- whether the file extension
+should be `task`, `taskpaper`, or omitted.
+
+### 2. Genesis: commit `!task` alongside `!md`
+
+`local_working_copy/genesis.go` gains a sibling helper next to
+`prepareDefaultType`:
+
+``` go
+func (local *Repo) prepareTaskType(
+    bigBang env_repo.BigBang,
+    builder *import_plan.Builder,
+) (objectIdType ids.TypeStruct, blobDigest domain_interfaces.MarklId, err error)
+```
+
+Behavior:
+
+- Allocates an `id.TypeStruct` for `task`.
+- Calls `type_blobs.DefaultTaskType()` to get the blob.
+- Saves the blob via the typed blob store, capturing the digest.
+- Constructs a `sku.Transacted` for the type object, sets its blob digest and
+  type (`!toml-type-v2`), and adds it to the import plan builder.
+- Returns the captured blob digest so the haustoria can stamp it on `Field`
+  records (see §3).
+
+`initDefaultTypeAndConfig` calls both `prepareDefaultType` and
+`prepareTaskType`. The `!task` blob digest is stored on the `Repo` (or fetched
+on demand via a query) so the haustoria initialization step can find it.
+
+The new step is gated on the existing `BigBang.ExcludeDefaultType` flag --- same
+flag that already gates `!md`. This means `init-workspace` and `clone` both skip
+it, which matches existing behavior for default types.
+
+No new `BigBang` field is added.
+
+### 3. Haustoria: VTODO ↔ `!task` field mapping
+
+`mike/haustoria_caldav/main.go` changes:
+
+**Drop `CalendarMapping.StatusTags`** and the
+`[haustoria.calendars.*.status-tags]` config keys in
+`echo/workspace_config_blobs`. Tommy codegen for the V2 workspace config is
+regenerated. The status-tag tests are deleted (see §4).
+
+**Add a `taskTypeBlobDigest` lookup on `Initialize`.** When `s.supplies` is set,
+the haustoria does a one-shot
+`s.supplies.ReadPrimitiveQuery(taskTypeQuery, ...)` to find the committed
+`!task` type object and caches its blob digest. If the type is missing
+(workspace, cloned repo with `ExcludeDefaultType`), the haustoria returns an
+init error pointing the user at the missing builtin --- the workspace mode isn't
+expected to host a CalDAV haustoria anyway.
+
+**Compile path (`queryCheckedOutForCalendar`)**: replace the `StatusTags` block
+with direct field projection.
+
+``` go
+metadata := external.GetMetadataMutable()
+indexFields := metadata.GetIndexMutable().GetFieldsMutable()
+
+statusValue := mapVTODOStatusToFieldValue(twm.Task.Status) // "todo" default
+indexFields.Add(fields.Field{
+    Key:            "status",
+    Value:          statusValue,
+    TypeBlobDigest: s.taskTypeBlobDigest,
+})
+
+if twm.Task.Priority != 0 {
+    indexFields.Add(fields.Field{
+        Key:            "priority",
+        Value:          strconv.Itoa(twm.Task.Priority),
+        TypeBlobDigest: s.taskTypeBlobDigest,
+    })
+}
+
+if twm.Task.Due != "" {
+    indexFields.Add(fields.Field{
+        Key:            "due",
+        Value:          twm.Task.Due,
+        TypeBlobDigest: s.taskTypeBlobDigest,
+    })
+}
+```
+
+The status value mapping:
+
+  VTODO STATUS     `!task` field value
+  ---------------- ---------------------
+  (absent)         `todo`
+  `NEEDS-ACTION`   `todo`
+  `IN-PROCESS`     `in-process`
+  `COMPLETED`      `done`
+  `CANCELLED`      `cancelled`
+
+Unknown values fall back to `todo` and log a warning at debug level.
+
+**Decompile path (`CheckoutOne`)**: pull the same fields out of
+`object.GetMetadata().GetIndex().GetFields()` and write them onto the
+`caldav.Task` before PUT. Currently `CheckoutOne` doesn't read fields at all and
+the existing decompile hardcodes `STATUS:NEEDS-ACTION`.
+
+The reverse status mapping is the inverse of the table above. `priority` is
+parsed back to `int`. `due` is passed through unchanged (CalDAV expects an iCal
+datetime string; we don't reformat it).
+
+### 4. Tests
+
+**Unit tests (Go)** for the haustoria:
+
+- `TestStatusValueRoundTrip` --- table-driven over the five VTODO STATUS values.
+- `TestPriorityRoundTrip` --- `0`, `1`, `5`, `9`.
+- `TestDuePassthrough` --- verbatim string passthrough.
+
+**BATS integration tests** in `zz-tests_bats/current_version/`:
+
+- Update existing 10 `caldav_*` tests to assert field projection in
+  `dodder status` output. Drop `caldav_status_tags_*` tests entirely (the
+  feature is removed).
+- Add `caldav_round_trip_status_field`: VTODO with `STATUS:COMPLETED` → checkin
+  → `dodder show` displays `status=done` → `dodder organize` to set
+  `status=todo` → checkout → CalDAV server has `STATUS:NEEDS-ACTION`.
+- Add `caldav_priority_and_due_round_trip`: same but for the other two fields.
+- Add `genesis_includes_task_type`: fresh `dodder init` then
+  `dodder show '!task:t'` produces a non-empty result with the field definitions
+  visible.
+
+**Fixture regeneration**: `dodder show :t` on a fresh-store BATS test will now
+include `!task` alongside `!md`. Run `just test-bats-update-fixtures` and commit
+the new `current_version` fixtures + `.fixtures.env`. The frozen v14 snapshot
+stays untouched.
+
+### 5. Live workspace migration (`~/workspaces/dodder-haustoria-caldav`)
+
+After the PR merges, the live workspace needs:
+
+1.  Edit `workspace/.dodder-workspace`: remove the three
+    `[haustoria.calendars.*.status-tags]` blocks. (No replacement --- fields are
+    projected unconditionally now.)
+2.  The repo is at store V14, code at V15. No format migration is needed; V14
+    reads fine on V15. Existing zettels (zero, in this case) keep working.
+3.  `dodder status` should now show field columns (`status=todo` /
+    `status=done`) on each untracked CalDAV resource.
+4.  The dormant filtering issue noted in the project memory becomes moot:
+    `dodder status '^status=done'` filters completed tasks at the doddish layer,
+    no need to reach into the dormant index from `mike/haustoria_caldav`.
+
+### 6. Docs
+
+- Update `docs/features/0007-checkout-bridges.md` status: `exploring` →
+  `experimental`. The promotion criteria ("CheckoutStore interface defined with
+  Compile/Decompile methods; at least one concrete store passes a round-trip
+  BATS test") are met by the existing CalDAV haustoria; this PR strengthens that
+  with field round-tripping.
+- Add a "superseded" addendum to
+  `docs/plans/2026-04-05-vtodo-langlang-design.md` pointing at this plan.
+- No new FDR for the `!task` type itself --- it's a built-in, not a feature.
+  Mention it in the FDR-0007 update instead.
+
+## Decisions to confirm
+
+These are open until you comment on this file:
+
+1.  **Status enum values**: `todo` / `in-process` / `done` / `cancelled`
+    (matches the field-mutation work in `19c6f63`). Alternative: keep VTODO
+    casing (`needs-action` / `in-process` / `completed` / `cancelled`).
+
+2.  **`!chore` handling**: drop `!chore` entirely and have both `tasks` and
+    `chores` calendars use `!task`. Alternative: ship `!task` and `!chore` as
+    two separate built-in types with the same field set.
+
+3.  **`ExcludeDefaultType` semantics**: gate `!task` under the existing flag
+    alongside `!md`. Alternative: separate `ExcludeDefaultTaskType` flag.
+
+4.  **`StatusTags` removal**: drop the field, the config key, and the tests in
+    one PR. Alternative: leave as a deprecated no-op for one release.
+
+5.  **`TypeBlobDigest` discovery**: one-shot `s.supplies.ReadPrimitiveQuery`
+    lookup on `Initialize`. Alternative: explicit accessor on the
+    `store_workspace.Supplies` struct
+    (e.g. `GetBuiltinTypeBlobDigest("!task")`).
+
+6.  **File extension on `!task`**: `task`, `taskpaper`, or omitted. The blob
+    isn't used for anything (the haustoria reads VTODOs from CalDAV, not from
+    files), so the extension only affects edit/checkout fallback paths.
+
+## Implementation order
+
+1.  Add `type_blobs.DefaultTaskType()` + unit test.
+2.  Wire `prepareTaskType` into `local_working_copy/genesis.go`.
+3.  Run `just test-bats-update-fixtures`, review and commit fixture diff.
+4.  Update `mike/haustoria_caldav` compile path: drop `StatusTags`, add field
+    projection. Drop `StatusTags` from `echo/workspace_config_blobs` config.
+5.  Update `mike/haustoria_caldav` decompile path: read fields from metadata,
+    write to VTODO.
+6.  Update / add BATS tests in `zz-tests_bats/current_version/`.
+7.  Update FDR-0007 status and add the supersede note to the !vtodo plan.
+8.  Test the live workspace, update its `.dodder-workspace`.
+
+## Risks
+
+- **Field digest binding**: if the genesis-committed `!task` type blob digest
+  drifts (e.g. someone changes `DefaultTaskType()` after the first commit on a
+  given repo), existing field records on already-checked-in objects will have a
+  stale `TypeBlobDigest`. This is the same risk that already exists for
+  user-defined types and the field round-trip via organize, so no new mitigation
+  is needed --- but worth noting in the FDR.
+
+- **Workspace status output churn**: every BATS test that does `dodder status`
+  in a haustoria workspace will now show field columns. The two-pass WRONG
+  assertion strategy in `CLAUDE.md` should be used to capture the new output.
+
+- **Forward compat with future built-in types**: this PR introduces the pattern
+  of "genesis commits more than just `!md`". Future built-in types (`!file`,
+  `!url`, `!event`?) follow the same template. No abstraction is needed yet ---
+  three call sites is the threshold for extracting a `prepareBuiltinTypes`
+  helper.

--- a/go/internal/bravo/ids/zettel_id_test.go
+++ b/go/internal/bravo/ids/zettel_id_test.go
@@ -42,4 +42,3 @@ func TestMakeHeadAndTail(t1 *testing.T) {
 		t.Errorf("expected %q but got %q", ex, ac)
 	}
 }
-

--- a/go/internal/charlie/blob_store_configs/toml_inventory_archive_v0.go
+++ b/go/internal/charlie/blob_store_configs/toml_inventory_archive_v0.go
@@ -17,7 +17,6 @@ type TomlInventoryArchiveV0 struct {
 	Encryption       markl.Id                         `toml:"encryption"`
 }
 
-
 func (TomlInventoryArchiveV0) GetBlobStoreType() string {
 	return "local-inventory-archive"
 }

--- a/go/internal/charlie/blob_store_configs/toml_inventory_archive_v1.go
+++ b/go/internal/charlie/blob_store_configs/toml_inventory_archive_v1.go
@@ -53,7 +53,6 @@ type TomlInventoryArchiveV1 struct {
 	MaxPackSize      uint64                           `toml:"max-pack-size"`
 }
 
-
 func (TomlInventoryArchiveV1) GetBlobStoreType() string {
 	return "local-inventory-archive"
 }

--- a/go/internal/charlie/blob_store_configs/toml_inventory_archive_v2.go
+++ b/go/internal/charlie/blob_store_configs/toml_inventory_archive_v2.go
@@ -17,7 +17,6 @@ type TomlInventoryArchiveV2 struct {
 	MaxPackSize     uint64                           `toml:"max-pack-size"`
 }
 
-
 func (TomlInventoryArchiveV2) GetBlobStoreType() string {
 	return "local-inventory-archive"
 }

--- a/go/internal/charlie/blob_store_configs/toml_uri_v0.go
+++ b/go/internal/charlie/blob_store_configs/toml_uri_v0.go
@@ -12,7 +12,6 @@ type TomlUriV0 struct {
 	Uri values.Uri `toml:"uri"`
 }
 
-
 func (config *TomlUriV0) SetFlagDefinitions(flagSet interfaces.CLIFlagDefinitions) {
 	flagSet.Var(
 		&config.Uri,

--- a/go/internal/charlie/blob_store_configs/toml_v1.go
+++ b/go/internal/charlie/blob_store_configs/toml_v1.go
@@ -25,7 +25,6 @@ type TomlLocalHashBucketedV1 struct {
 	LockInternalFiles bool                             `toml:"lock-internal-files"`
 }
 
-
 func (TomlLocalHashBucketedV1) GetBlobStoreType() string {
 	return "local"
 }

--- a/go/internal/charlie/blob_store_configs/toml_v2.go
+++ b/go/internal/charlie/blob_store_configs/toml_v2.go
@@ -25,7 +25,6 @@ type TomlLocalHashBucketedV2 struct {
 	LockInternalFiles bool                             `toml:"lock-internal-files"`
 }
 
-
 func (TomlLocalHashBucketedV2) GetBlobStoreType() string {
 	return "local"
 }

--- a/go/internal/charlie/blob_store_configs/toml_v3.go
+++ b/go/internal/charlie/blob_store_configs/toml_v3.go
@@ -20,7 +20,6 @@ type TomlV3 struct {
 	LockInternalFiles bool                             `toml:"lock-internal-files"`
 }
 
-
 func (TomlV3) GetBlobStoreType() string {
 	return "local"
 }

--- a/go/internal/delta/blob_store_configs/main.go
+++ b/go/internal/delta/blob_store_configs/main.go
@@ -75,20 +75,20 @@ var (
 
 // Interface satisfaction checks
 var (
-	_ ConfigSFTPRemotePath    = &TomlSFTPV0{}
-	_ ConfigSFTPRemotePath    = &TomlSFTPViaSSHConfigV0{}
-	_ ConfigMutable           = &TomlSFTPV0{}
-	_ ConfigLocalHashBucketed = TomlLocalHashBucketedV1{}
-	_ ConfigUpgradeable       = TomlLocalHashBucketedV1{}
-	_ ConfigLocalMutable      = &TomlLocalHashBucketedV1{}
-	_ ConfigLocalHashBucketed = TomlLocalHashBucketedV2{}
-	_ ConfigUpgradeable       = TomlLocalHashBucketedV2{}
-	_ ConfigLocalMutable      = &TomlLocalHashBucketedV2{}
-	_ ConfigLocalHashBucketed = TomlV3{}
-	_ ConfigLocalMutable      = &TomlV3{}
-	_ ConfigMutable           = &TomlV3{}
-	_ ConfigPointer           = TomlPointerV0{}
-	_ ConfigMutable           = &TomlPointerV0{}
+	_ ConfigSFTPRemotePath        = &TomlSFTPV0{}
+	_ ConfigSFTPRemotePath        = &TomlSFTPViaSSHConfigV0{}
+	_ ConfigMutable               = &TomlSFTPV0{}
+	_ ConfigLocalHashBucketed     = TomlLocalHashBucketedV1{}
+	_ ConfigUpgradeable           = TomlLocalHashBucketedV1{}
+	_ ConfigLocalMutable          = &TomlLocalHashBucketedV1{}
+	_ ConfigLocalHashBucketed     = TomlLocalHashBucketedV2{}
+	_ ConfigUpgradeable           = TomlLocalHashBucketedV2{}
+	_ ConfigLocalMutable          = &TomlLocalHashBucketedV2{}
+	_ ConfigLocalHashBucketed     = TomlV3{}
+	_ ConfigLocalMutable          = &TomlV3{}
+	_ ConfigMutable               = &TomlV3{}
+	_ ConfigPointer               = TomlPointerV0{}
+	_ ConfigMutable               = &TomlPointerV0{}
 	_ ConfigInventoryArchive      = TomlInventoryArchiveV0{}
 	_ ConfigUpgradeable           = TomlInventoryArchiveV0{}
 	_ ConfigMutable               = &TomlInventoryArchiveV0{}

--- a/go/internal/delta/repo_configs/main.go
+++ b/go/internal/delta/repo_configs/main.go
@@ -26,11 +26,11 @@ type (
 )
 
 var (
-	DecodeV0                       = charlie_rc.DecodeV0
-	DecodeV1                       = charlie_rc.DecodeV1
-	DecodeV2                       = charlie_rc.DecodeV2
-	DecodeDefaultsV1OmitEmptyInto  = charlie_rc.DecodeDefaultsV1OmitEmptyInto
-	EncodeDefaultsV1OmitEmptyFrom  = charlie_rc.EncodeDefaultsV1OmitEmptyFrom
+	DecodeV0                      = charlie_rc.DecodeV0
+	DecodeV1                      = charlie_rc.DecodeV1
+	DecodeV2                      = charlie_rc.DecodeV2
+	DecodeDefaultsV1OmitEmptyInto = charlie_rc.DecodeDefaultsV1OmitEmptyInto
+	EncodeDefaultsV1OmitEmptyFrom = charlie_rc.EncodeDefaultsV1OmitEmptyFrom
 )
 
 type (

--- a/go/internal/echo/workspace_config_blobs/v2.go
+++ b/go/internal/echo/workspace_config_blobs/v2.go
@@ -26,10 +26,9 @@ type CalDAVConfig struct {
 
 // CalendarConfig maps a CalDAV calendar to a dodder type and optional tags.
 type CalendarConfig struct {
-	URL        string            `toml:"url"`
-	Type       string            `toml:"type"`
-	Tags       []string          `toml:"tags,omitempty"`
-	StatusTags map[string]string `toml:"status-tags,omitempty"`
+	URL  string   `toml:"url"`
+	Type string   `toml:"type"`
+	Tags []string `toml:"tags,omitempty"`
 }
 
 // OrgmodeConfig holds orgmode haustoria connection parameters. Supports

--- a/go/internal/echo/workspace_config_blobs/v2_tommy.go
+++ b/go/internal/echo/workspace_config_blobs/v2_tommy.go
@@ -187,16 +187,6 @@ func DecodeV2(input []byte) (*V2Document, error) {
 							}
 						}
 					}
-					for _, _ch := range d.cstDoc.Root().Children {
-						if _ch.Kind == cst.NodeTable && cst.TableHeaderKey(_ch) == "haustoria.calendars."+_mk+"."+"status-tags" {
-							entry.StatusTags = cst.ExtractStringMap(_ch)
-							d.consumed["haustoria.calendars."+_mk+"."+"status-tags"] = true
-							for _ik := range entry.StatusTags {
-								d.consumed["haustoria.calendars."+_mk+"."+"status-tags"+"."+_ik] = true
-							}
-							break
-						}
-					}
 					_mr[_mk] = entry
 				}
 				if _mr != nil {
@@ -674,15 +664,6 @@ func (d *V2Document) Encode() ([]byte, error) {
 						}
 					}
 				}
-				if len(mapVal.StatusTags) > 0 {
-					tableNode := cst.EnsureChildTable(d.cstDoc.Root(), subTable, "status-tags")
-					cst.DeleteAllValues(tableNode)
-					for k, v := range mapVal.StatusTags {
-						if err := cst.SetAny(tableNode, k, v); err != nil {
-							return nil, fmt.Errorf("%w", err)
-						}
-					}
-				}
 			}
 		}
 		if d.data.Haustoria.Orgmode != nil {
@@ -927,16 +908,6 @@ func DecodeV2Into(data *V2, doc *document.Document, container *cst.Node, consume
 								entry.Tags = v
 								consumed[keyPrefix+keyPrefix+"haustoria.calendars."+_mk+"."+"tags"] = true
 							}
-						}
-					}
-					for _, _ch := range doc.Root().Children {
-						if _ch.Kind == cst.NodeTable && cst.TableHeaderKey(_ch) == keyPrefix+keyPrefix+"haustoria.calendars."+_mk+"."+"status-tags" {
-							entry.StatusTags = cst.ExtractStringMap(_ch)
-							consumed[keyPrefix+keyPrefix+"haustoria.calendars."+_mk+"."+"status-tags"] = true
-							for _ik := range entry.StatusTags {
-								consumed[keyPrefix+keyPrefix+"haustoria.calendars."+_mk+"."+"status-tags"+"."+_ik] = true
-							}
-							break
 						}
 					}
 					_mr[_mk] = entry
@@ -1409,15 +1380,6 @@ func EncodeV2From(data *V2, doc *document.Document, container *cst.Node) error {
 				{
 					if len(mapVal.Tags) > 0 || cst.HasValue(subTable, "tags") {
 						if err := cst.SetAny(subTable, "tags", mapVal.Tags); err != nil {
-							return fmt.Errorf("%w", err)
-						}
-					}
-				}
-				if len(mapVal.StatusTags) > 0 {
-					tableNode := cst.EnsureChildTable(doc.Root(), subTable, "status-tags")
-					cst.DeleteAllValues(tableNode)
-					for k, v := range mapVal.StatusTags {
-						if err := cst.SetAny(tableNode, k, v); err != nil {
 							return fmt.Errorf("%w", err)
 						}
 					}

--- a/go/internal/foxtrot/zettel_id_index/main.go
+++ b/go/internal/foxtrot/zettel_id_index/main.go
@@ -35,7 +35,6 @@ func MakeIndex(
 			err = errors.Wrap(err)
 			return i, err
 		}
-
 	} else {
 		if i, err = hinweis_index_v0.MakeIndex(
 			configCli,

--- a/go/internal/golf/env_repo/big_bang.go
+++ b/go/internal/golf/env_repo/big_bang.go
@@ -17,12 +17,13 @@ type BigBang struct {
 
 	PrivateKey markl.Id
 
-	Yin                       string
-	Yang                      string
-	ExcludeDefaultType        bool
-	ExcludeDefaultConfig      bool
-	IncludeDefaultPandocTools bool
-	BlobStoreId               blob_store_id.Id
+	Yin                           string
+	Yang                          string
+	ExcludeDefaultType            bool
+	ExcludeDefaultConfig          bool
+	IncludeDefaultPandocTools     bool
+	IncludeBuiltinActionableTypes bool
+	BlobStoreId                   blob_store_id.Id
 }
 
 func (bigBang *BigBang) SetDefaults() {

--- a/go/internal/golf/type_blobs/main.go
+++ b/go/internal/golf/type_blobs/main.go
@@ -41,6 +41,81 @@ func DefaultPandocLuaFilter() TomlV2 {
 	}
 }
 
+// actionableFields is the field set shared by !task and !chore. Both built-in
+// types use the same status/priority/due triple. Future work
+// (see docs/plans/2026-04-06-task-type-genesis-and-haustoria-fields.md §1a)
+// is to extract this into an !actionable abstract type that both compose
+// against.
+func actionableFields() []FieldDefinition {
+	return []FieldDefinition{
+		{
+			Name:    "status",
+			Kind:    "enum",
+			Values:  []string{"todo", "in_progress", "done", "cancelled"},
+			Default: "todo",
+		},
+		{
+			Name:    "priority",
+			Kind:    "enum",
+			Values:  []string{"p0", "p1", "p2", "p3"},
+			Default: "p3",
+		},
+		{
+			Name: "due",
+			Kind: "string",
+		},
+	}
+}
+
+// actionableFieldsReader returns the yq script that projects fields from a
+// TOML blob into Metadata.Index.Fields during commit. The output JSON keys
+// must match the field names declared by actionableFields.
+func actionableFieldsReader() *script_config.ScriptConfig {
+	return &script_config.ScriptConfig{
+		Script: `yq -p toml -o json '{"status": .status, "priority": .priority, "due": .due}'`,
+	}
+}
+
+// actionableFieldsWriter returns the yq script that projects field edits back
+// into the TOML blob during organize mutations. Reads DODDER_FIELD_status,
+// DODDER_FIELD_priority, DODDER_FIELD_due env vars and writes them into the
+// blob at DODDER_BLOB_PATH.
+func actionableFieldsWriter() *script_config.ScriptConfig {
+	return &script_config.ScriptConfig{
+		Script: `yq -p toml -o toml -i ".status = \"$DODDER_FIELD_status\" | .priority = \"$DODDER_FIELD_priority\" | .due = \"$DODDER_FIELD_due\"" "$DODDER_BLOB_PATH"`,
+	}
+}
+
+// DefaultTaskType returns the built-in !task type blob, used by genesis when
+// BigBang.IncludeBuiltinActionableTypes is set. !task instances are stored as
+// TOML blobs mirroring the field values; the reader script projects them into
+// the index on commit, the writer script projects user edits back into the
+// blob during organize mutations. The CalDAV haustoria emits these blobs
+// directly during compile.
+func DefaultTaskType() TomlV2 {
+	return TomlV2{
+		FileExtension: "toml",
+		VimSyntaxType: "toml",
+		Fields:        actionableFields(),
+		FieldsReader:  actionableFieldsReader(),
+		FieldsWriter:  actionableFieldsWriter(),
+	}
+}
+
+// DefaultChoreType returns the built-in !chore type blob. Same field set as
+// !task; calendar-to-type binding stays a workspace config concern (the
+// CalDAV haustoria's tasks calendar binds to !task and chores binds to
+// !chore). Future !actionable abstract type will replace the duplication.
+func DefaultChoreType() TomlV2 {
+	return TomlV2{
+		FileExtension: "toml",
+		VimSyntaxType: "toml",
+		Fields:        actionableFields(),
+		FieldsReader:  actionableFieldsReader(),
+		FieldsWriter:  actionableFieldsWriter(),
+	}
+}
+
 type Blob interface {
 	GetFileExtension() string
 	GetBinary() bool

--- a/go/internal/golf/type_blobs/main_test.go
+++ b/go/internal/golf/type_blobs/main_test.go
@@ -1,0 +1,136 @@
+//go:build test
+
+package type_blobs
+
+import (
+	"strings"
+	"testing"
+
+	"code.linenisgreat.com/dodder/go/lib/charlie/ui"
+)
+
+func TestDefaultTaskType(t1 *testing.T) {
+	t := ui.T{T: t1}
+
+	blob := DefaultTaskType()
+
+	if blob.FileExtension != "toml" {
+		t.Errorf("expected file-extension %q, got %q", "toml", blob.FileExtension)
+	}
+
+	if blob.VimSyntaxType != "toml" {
+		t.Errorf("expected vim-syntax-type %q, got %q", "toml", blob.VimSyntaxType)
+	}
+
+	assertActionableFields(t, blob.Fields)
+
+	if blob.FieldsReader == nil {
+		t.Fatalf("expected non-nil FieldsReader")
+	}
+
+	if !strings.Contains(blob.FieldsReader.Script, "yq -p toml -o json") {
+		t.Errorf("FieldsReader script missing yq invocation: %q", blob.FieldsReader.Script)
+	}
+
+	if blob.FieldsWriter == nil {
+		t.Fatalf("expected non-nil FieldsWriter")
+	}
+
+	if !strings.Contains(blob.FieldsWriter.Script, "DODDER_FIELD_status") {
+		t.Errorf("FieldsWriter script missing DODDER_FIELD_status: %q", blob.FieldsWriter.Script)
+	}
+
+	if !strings.Contains(blob.FieldsWriter.Script, "DODDER_BLOB_PATH") {
+		t.Errorf("FieldsWriter script missing DODDER_BLOB_PATH: %q", blob.FieldsWriter.Script)
+	}
+}
+
+func TestDefaultChoreType(t1 *testing.T) {
+	t := ui.T{T: t1}
+
+	blob := DefaultChoreType()
+
+	if blob.FileExtension != "toml" {
+		t.Errorf("expected file-extension %q, got %q", "toml", blob.FileExtension)
+	}
+
+	assertActionableFields(t, blob.Fields)
+
+	// chore and task currently share the exact same field set + scripts;
+	// this is enforced by both calling actionableFields/Reader/Writer.
+	taskBlob := DefaultTaskType()
+
+	if blob.FieldsReader.Script != taskBlob.FieldsReader.Script {
+		t.Errorf("chore and task FieldsReader scripts diverged")
+	}
+
+	if blob.FieldsWriter.Script != taskBlob.FieldsWriter.Script {
+		t.Errorf("chore and task FieldsWriter scripts diverged")
+	}
+}
+
+func assertActionableFields(t ui.T, fields []FieldDefinition) {
+	if len(fields) != 3 {
+		t.Fatalf("expected 3 fields, got %d", len(fields))
+	}
+
+	expected := []struct {
+		name      string
+		kind      string
+		values    []string
+		dflt      string
+		hasValues bool
+	}{
+		{
+			name:      "status",
+			kind:      "enum",
+			values:    []string{"todo", "in_progress", "done", "cancelled"},
+			dflt:      "todo",
+			hasValues: true,
+		},
+		{
+			name:      "priority",
+			kind:      "enum",
+			values:    []string{"p0", "p1", "p2", "p3"},
+			dflt:      "p3",
+			hasValues: true,
+		},
+		{
+			name:      "due",
+			kind:      "string",
+			hasValues: false,
+		},
+	}
+
+	for i, want := range expected {
+		got := fields[i]
+
+		if got.Name != want.name {
+			t.Errorf("field %d: expected name %q, got %q", i, want.name, got.Name)
+		}
+
+		if got.Kind != want.kind {
+			t.Errorf("field %d: expected kind %q, got %q", i, want.kind, got.Kind)
+		}
+
+		if got.Default != want.dflt {
+			t.Errorf("field %d: expected default %q, got %q", i, want.dflt, got.Default)
+		}
+
+		if want.hasValues {
+			if len(got.Values) != len(want.values) {
+				t.Fatalf("field %d (%s): expected %d values, got %d", i, want.name, len(want.values), len(got.Values))
+			}
+
+			for j := range want.values {
+				if got.Values[j] != want.values[j] {
+					t.Errorf("field %d (%s) value %d: expected %q, got %q", i, want.name, j, want.values[j], got.Values[j])
+				}
+			}
+		} else {
+			if len(got.Values) != 0 {
+				t.Errorf("field %d (%s): expected no values, got %v", i, want.name, got.Values)
+			}
+		}
+	}
+}

--- a/go/internal/hotel/type_blobs/main.go
+++ b/go/internal/hotel/type_blobs/main.go
@@ -24,6 +24,8 @@ var (
 	DefaultWithPandocFormatter = golf_tb.DefaultWithPandocFormatter
 	DefaultPandocDefaults      = golf_tb.DefaultPandocDefaults
 	DefaultPandocLuaFilter     = golf_tb.DefaultPandocLuaFilter
+	DefaultTaskType            = golf_tb.DefaultTaskType
+	DefaultChoreType           = golf_tb.DefaultChoreType
 )
 
 var (

--- a/go/internal/juliett/typed_blob_store/tag.go
+++ b/go/internal/juliett/typed_blob_store/tag.go
@@ -257,7 +257,6 @@ func (noopBlobDecoder[BLOB, BLOB_PTR]) DecodeFrom(
 	reader io.Reader,
 ) (n int64, err error) {
 	n, err = io.Copy(io.Discard, reader)
-
 	if err != nil {
 		err = errors.Wrap(err)
 	}

--- a/go/internal/mike/haustoria_caldav/checked_out.go
+++ b/go/internal/mike/haustoria_caldav/checked_out.go
@@ -1,0 +1,219 @@
+package haustoria_caldav
+
+import (
+	"code.linenisgreat.com/dodder/go/internal/alfa/checkout_options"
+	"code.linenisgreat.com/dodder/go/internal/alfa/genres"
+	"code.linenisgreat.com/dodder/go/internal/bravo/checked_out_state"
+	"code.linenisgreat.com/dodder/go/internal/golf/sku"
+	"code.linenisgreat.com/dodder/go/internal/hotel/caldav"
+	"code.linenisgreat.com/dodder/go/internal/lima/store_workspace"
+	"code.linenisgreat.com/dodder/go/lib/bravo/errors"
+)
+
+// Compile-time interface checks for the optional store_workspace methods
+// that the dodder commit / merge / organize paths probe via type
+// assertion. The papa store calls these whenever
+// `options.MergeCheckedOut` is set during a commit (e.g. from `dodder
+// organize`), so a haustoria workspace MUST satisfy them or organize
+// fails with "store does not support operation '**env_workspace.Store'".
+var (
+	_ store_workspace.ReadCheckedOutFromTransacted   = &Store{}
+	_ store_workspace.UpdateCheckoutFromCheckedOut   = &Store{}
+	_ store_workspace.Merge                          = &Store{}
+)
+
+// ReadCheckedOutFromTransacted returns the live external state of an
+// internal dodder object by fetching the corresponding VTODO from CalDAV.
+// Used by the merge path during commit to compare the internal version
+// against the current remote state.
+//
+// Lookup strategy: the internal object's ExternalObjectId is the VTODO
+// UID (set during the original CheckinHaustoria run). The calendar is
+// resolved by matching the object's type against each CalendarMapping's
+// TypeId. The .ics resource is fetched once via HTTP GET; the response
+// is rebuilt into a TOML blob via buildTaskTomlBlob and projected into
+// a fresh `*sku.CheckedOut`.
+//
+// TODO #103: cache CalDAV resources via ETag/LastModified to avoid an
+// HTTP round-trip per organize commit. The current implementation hits
+// the network for every call.
+func (s *Store) ReadCheckedOutFromTransacted(
+	object *sku.Transacted,
+) (checkedOut *sku.CheckedOut, err error) {
+	eoid := object.GetExternalObjectId()
+	if eoid.IsEmpty() {
+		return nil, errors.MakeErrNotFound(object.GetObjectId())
+	}
+
+	cal := s.calendarForType(object.GetMetadata().GetType().String())
+	if cal == nil {
+		return nil, errors.MakeErrNotFound(object.GetObjectId())
+	}
+
+	href := cal.URL + eoid.String() + ".ics"
+
+	meta, err := s.client.GetTask(href)
+	if err != nil {
+		return nil, errors.Wrapf(err,
+			"fetch CalDAV task %s for organize merge", eoid.String(),
+		)
+	}
+
+	checkedOut, _ = sku.GetCheckedOutPool().GetWithRepool() //repool:owned
+
+	// internal slot: the dodder-side object as it exists in the store
+	sku.TransactedResetter.ResetWith(checkedOut.GetSku(), object)
+
+	// external slot: the freshly-built remote state, sharing the same
+	// object id but with a blob digest derived from the just-fetched
+	// VTODO. The reader script will project status / priority / due into
+	// the index when the daughter is committed.
+	external := checkedOut.GetSkuExternal()
+	sku.TransactedResetter.ResetWith(external, object)
+
+	if err = external.GetMetadataMutable().GetDescriptionMutable().Set(
+		meta.Task.Summary,
+	); err != nil {
+		return nil, errors.Wrap(err)
+	}
+
+	if cal.TypeId != "" {
+		if err = external.GetMetadataMutable().GetTypeMutable().SetType(
+			cal.TypeId,
+		); err != nil {
+			return nil, errors.Wrap(err)
+		}
+	}
+
+	for _, tagStr := range cal.Tags {
+		if addErr := external.GetMetadataMutable().AddTagString(tagStr); addErr != nil {
+			continue
+		}
+	}
+
+	for _, tagStr := range meta.Task.Categories {
+		if addErr := external.GetMetadataMutable().AddTagString(tagStr); addErr != nil {
+			continue
+		}
+	}
+
+	blob := buildTaskTomlBlob(&meta.Task)
+	if err = s.writeBlob(external, blob); err != nil {
+		return nil, errors.Wrapf(err,
+			"rewrite blob for %s during merge fetch", eoid.String(),
+		)
+	}
+
+	if err = external.GetExternalObjectIdMutable().SetWithGenre(
+		meta.Task.UID,
+		genres.Zettel,
+	); err != nil {
+		return nil, errors.Wrap(err)
+	}
+
+	checkedOut.SetState(checked_out_state.CheckedOut)
+	return checkedOut, nil
+}
+
+// UpdateCheckoutFromCheckedOut pushes the resolved external state of a
+// CheckedOut pair back to CalDAV via PUT. Called by the merging fast
+// path after the daughter has been merged with the live remote state.
+//
+// The external slot's blob is the TOML projection of the merged field
+// values; we parse it back to a Task struct and re-emit as iCal.
+func (s *Store) UpdateCheckoutFromCheckedOut(
+	options checkout_options.OptionsWithoutMode,
+	object sku.SkuType,
+) (err error) {
+	external := object.GetSkuExternal()
+
+	// The merging fast path in papa/store/merging.go:48 calls
+	// ResetWithExceptFields(right=external, left=daughter), which
+	// overwrites external.ExternalObjectId with the daughter's empty
+	// value (organize doesn't carry the binding). Fall back to the
+	// internal slot, which still has the original CalDAV UID.
+	eoid := external.GetExternalObjectId()
+	if eoid.IsEmpty() {
+		eoid = object.GetSku().GetExternalObjectId()
+	}
+	if eoid.IsEmpty() {
+		return errors.ErrorWithStackf(
+			"cannot push external update without ExternalObjectId for %s",
+			external.GetObjectId(),
+		)
+	}
+
+	typeId := external.GetMetadata().GetType().String()
+
+	cal := s.calendarForType(typeId)
+	if cal == nil {
+		return errors.ErrorWithStackf(
+			"no calendar mapping for type %s when pushing organize update",
+			typeId,
+		)
+	}
+
+	// Pull the TOML blob via the metadata's blob digest. After the merging
+	// fast path's ResetWithExceptFields, the external slot's blob digest
+	// is the daughter's freshly-written digest from tryWriteFields. Read
+	// directly through GetMetadata() to avoid an Id.IsNull panic on a
+	// not-fully-typed digest copy.
+	blobDigest := external.GetMetadata().GetBlobDigest()
+
+	var blobBytes []byte
+	if len(blobDigest.GetBytes()) > 0 {
+		if blobBytes, err = s.readBlob(external.GetSku()); err != nil {
+			return errors.Wrapf(err,
+				"read blob for %s during organize push", eoid.String(),
+			)
+		}
+	}
+
+	values := parseTaskTomlBlob(blobBytes)
+
+	var tags []string
+	for tag := range external.GetMetadata().GetTags().All() {
+		tags = append(tags, tag.String())
+	}
+
+	task := caldav.Task{
+		UID:         eoid.String(),
+		Summary:     external.GetMetadata().GetDescription().String(),
+		Description: values.Notes,
+		Categories:  tags,
+		Status:      mapFieldValueToVTODOStatus(values.Status),
+		Priority:    mapFieldValueToVTODOPriority(values.Priority),
+		Due:         values.Due,
+	}
+
+	ical := caldav.TaskToIcal(&task)
+	href := cal.URL + task.UID + ".ics"
+
+	if err = s.client.PutTask(href, ical, ""); err != nil {
+		return errors.Wrapf(err,
+			"PUT VTODO %s to CalDAV during organize push", task.UID,
+		)
+	}
+
+	return nil
+}
+
+// Merge resolves a 3-way merge conflict between the local edit, the
+// fetched remote state, and the common ancestor. The current
+// implementation does NOT attempt structural merging — it punts to
+// last-write-wins by accepting the local edit (the daughter being
+// committed) and letting the subsequent UpdateCheckoutFromCheckedOut
+// push it to CalDAV. Conflict resolution belongs to the broader
+// remote_transfer redesign tracked in #19.
+//
+// In practice the merging fast path in papa/store/merging.go avoids
+// this method when the fetched remote equals the dodder-side mother,
+// which is the common case for organize-driven edits between sync
+// cycles.
+func (s *Store) Merge(conflicted sku.Conflicted) (err error) {
+	// Accept the local edit verbatim. The caller has already populated
+	// conflicted.Local with the daughter being committed; we leave the
+	// CheckedOut pair as-is so the post-merge UpdateCheckoutFromCheckedOut
+	// pushes the local state to CalDAV (last-write-wins toward dodder).
+	return nil
+}

--- a/go/internal/mike/haustoria_caldav/main.go
+++ b/go/internal/mike/haustoria_caldav/main.go
@@ -22,10 +22,9 @@ import (
 // CalendarMapping associates a CalDAV calendar URL with a dodder type and
 // optional tags.
 type CalendarMapping struct {
-	URL        string
-	TypeId     string
-	Tags       []string
-	StatusTags map[string]string // CalDAV STATUS → dodder tag
+	URL    string
+	TypeId string
+	Tags   []string
 }
 
 // Store implements both haustoria.Haustoria and store_workspace.StoreLike
@@ -134,17 +133,16 @@ func (s *Store) queryCheckedOutForCalendar(
 			}
 		}
 
-		// Map CalDAV STATUS to a dodder tag via config.
-		if tag, ok := cal.StatusTags[twm.Task.Status]; ok {
-			if addErr := metadata.AddTagString(tag); addErr != nil {
-				// skip invalid tag
-			}
-		}
-
-		if twm.Task.Description != "" {
-			if err = s.writeBlob(external, []byte(twm.Task.Description)); err != nil {
-				return errors.Wrapf(err, "write blob for %s", twm.Task.UID)
-			}
+		// Build the !task TOML blob with status, priority, due baked in
+		// (the reader script declared on !task projects them into
+		// Metadata.Index.Fields during commit). The VTODO DESCRIPTION text
+		// is stored as a `notes` key in the blob — present in the file but
+		// NOT declared as a [[fields]] entry on !task, so it doesn't
+		// appear as a queryable field for now (#TODO promote to field
+		// once the round-trip story is proven).
+		blob := buildTaskTomlBlob(&twm.Task)
+		if err = s.writeBlob(external, blob); err != nil {
+			return errors.Wrapf(err, "write task blob for %s", twm.Task.UID)
 		}
 
 		if err = external.GetExternalObjectIdMutable().SetWithGenre(

--- a/go/internal/mike/haustoria_caldav/main.go
+++ b/go/internal/mike/haustoria_caldav/main.go
@@ -192,8 +192,15 @@ func (s *Store) CheckoutOne(
 		}
 	}
 
+	// Preserve the CalDAV UID across the round-trip. Without this,
+	// Decompile would generate a fresh `dodder-N@dodder` UID, breaking
+	// the binding between the dodder object and its remote VTODO and
+	// orphaning the original .ics file on the server.
+	externalId := object.GetExternalObjectId().String()
+
 	result, err := s.Decompile(haustoria.DecompileRequest{
 		ObjectId:    object.GetObjectId().String(),
+		ExternalId:  externalId,
 		Description: description,
 		Blob:        blob,
 		Tags:        tags,

--- a/go/internal/mike/haustoria_caldav/main.go
+++ b/go/internal/mike/haustoria_caldav/main.go
@@ -319,12 +319,22 @@ func (s *Store) Decompile(req haustoria.DecompileRequest) (haustoria.DecompileRe
 		)
 	}
 
+	// Parse the !task TOML blob (produced by buildTaskTomlBlob during the
+	// compile path or by the type's fields-writer script during organize
+	// edits) to recover status / priority / due / notes. The blob is the
+	// canonical source of truth — we don't read from Metadata.Index.Fields
+	// here so the path works whether or not the !task type with reader
+	// script is committed in the repo.
+	values := parseTaskTomlBlob(req.Blob)
+
 	task := caldav.Task{
 		UID:         req.ExternalId,
 		Summary:     req.Description,
-		Description: string(req.Blob),
+		Description: values.Notes,
 		Categories:  req.Tags,
-		Status:      "NEEDS-ACTION",
+		Status:      mapFieldValueToVTODOStatus(values.Status),
+		Priority:    mapFieldValueToVTODOPriority(values.Priority),
+		Due:         values.Due,
 	}
 
 	if task.UID == "" {

--- a/go/internal/mike/haustoria_caldav/task_blob.go
+++ b/go/internal/mike/haustoria_caldav/task_blob.go
@@ -1,0 +1,124 @@
+package haustoria_caldav
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+
+	"code.linenisgreat.com/dodder/go/internal/hotel/caldav"
+)
+
+// buildTaskTomlBlob serializes a CalDAV VTODO into the TOML blob format
+// expected by the !task / !chore built-in types. The blob contains four
+// keys:
+//
+//   - status   : enum projected as a typed field via the !task fields-reader
+//   - priority : enum projected as a typed field
+//   - due      : string projected as a typed field
+//   - notes    : free-form text — present in the blob but NOT declared as a
+//     [[fields]] entry on !task. Holds the VTODO DESCRIPTION text. Promote
+//     to a typed field once the round-trip story is proven.
+//
+// All four keys are always emitted (with empty-string defaults for due and
+// notes) so the blob shape is stable across compile cycles.
+func buildTaskTomlBlob(task *caldav.Task) []byte {
+	var buf bytes.Buffer
+
+	fmt.Fprintf(&buf, "status = %s\n", quoteTomlString(mapVTODOStatusToFieldValue(task.Status)))
+	fmt.Fprintf(&buf, "priority = %s\n", quoteTomlString(mapVTODOPriorityToFieldValue(task.Priority)))
+	fmt.Fprintf(&buf, "due = %s\n", quoteTomlString(task.Due))
+	fmt.Fprintf(&buf, "notes = %s\n", quoteTomlString(task.Description))
+
+	return buf.Bytes()
+}
+
+// quoteTomlString emits a TOML basic string literal. strconv.Quote produces
+// the same backslash-escape syntax that TOML basic strings accept (\", \\,
+// \n, \r, \t, \uXXXX), with the exception of \a / \v which TOML doesn't
+// support — but those don't appear in CalDAV text fields in practice.
+func quoteTomlString(s string) string {
+	return strconv.Quote(s)
+}
+
+// mapVTODOStatusToFieldValue maps the iCalendar VTODO STATUS property to a
+// !task `status` field value per the table in
+// docs/plans/2026-04-06-task-type-genesis-and-haustoria-fields.md §3.
+//
+// Unknown values fall back to the "todo" default.
+func mapVTODOStatusToFieldValue(vtodoStatus string) string {
+	switch vtodoStatus {
+	case "":
+		return "todo"
+	case "NEEDS-ACTION":
+		return "todo"
+	case "IN-PROCESS":
+		return "in_progress"
+	case "COMPLETED":
+		return "done"
+	case "CANCELLED":
+		return "cancelled"
+	default:
+		return "todo"
+	}
+}
+
+// mapFieldValueToVTODOStatus is the inverse of mapVTODOStatusToFieldValue,
+// used by the decompile path. The "todo" field value rounds back to
+// NEEDS-ACTION (the canonical "open task" VTODO STATUS).
+func mapFieldValueToVTODOStatus(fieldValue string) string {
+	switch fieldValue {
+	case "todo":
+		return "NEEDS-ACTION"
+	case "in_progress":
+		return "IN-PROCESS"
+	case "done":
+		return "COMPLETED"
+	case "cancelled":
+		return "CANCELLED"
+	default:
+		return "NEEDS-ACTION"
+	}
+}
+
+// mapVTODOPriorityToFieldValue maps the numeric iCalendar VTODO PRIORITY
+// property (0-9, where 0 means "no priority" and 1 is highest) to a !task
+// `priority` field value per the table in §1 of the plan:
+//
+//	0 (or absent) → p3 (default)
+//	1, 2          → p0 (highest, !!!)
+//	3, 4, 5       → p1 (!!)
+//	6, 7, 8, 9    → p2 (!)
+//
+// Out-of-range values fall back to the "p3" default.
+func mapVTODOPriorityToFieldValue(vtodoPriority int) string {
+	switch {
+	case vtodoPriority <= 0:
+		return "p3"
+	case vtodoPriority <= 2:
+		return "p0"
+	case vtodoPriority <= 5:
+		return "p1"
+	case vtodoPriority <= 9:
+		return "p2"
+	default:
+		return "p3"
+	}
+}
+
+// mapFieldValueToVTODOPriority is the inverse of mapVTODOPriorityToFieldValue.
+// Emits the canonical numeric value for each bucket (1, 5, 9) plus 0 for
+// "no priority".
+func mapFieldValueToVTODOPriority(fieldValue string) int {
+	switch fieldValue {
+	case "p0":
+		return 1
+	case "p1":
+		return 5
+	case "p2":
+		return 9
+	case "p3":
+		return 0
+	default:
+		return 0
+	}
+}

--- a/go/internal/mike/haustoria_caldav/task_blob.go
+++ b/go/internal/mike/haustoria_caldav/task_blob.go
@@ -4,9 +4,21 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"code.linenisgreat.com/dodder/go/internal/hotel/caldav"
 )
+
+// taskBlobValues is the parsed in-memory shape of a !task TOML blob, used by
+// the decompile path. The four keys correspond to the keys emitted by
+// buildTaskTomlBlob in the compile path. Round-trip through
+// parseTaskTomlBlob → buildTaskTomlBlob preserves all values.
+type taskBlobValues struct {
+	Status   string
+	Priority string
+	Due      string
+	Notes    string
+}
 
 // buildTaskTomlBlob serializes a CalDAV VTODO into the TOML blob format
 // expected by the !task / !chore built-in types. The blob contains four
@@ -121,4 +133,51 @@ func mapFieldValueToVTODOPriority(fieldValue string) int {
 	default:
 		return 0
 	}
+}
+
+// parseTaskTomlBlob parses a !task TOML blob produced by buildTaskTomlBlob.
+// The format is constrained: each of the four keys appears as a single line
+// `key = "value"` where the value is a TOML basic string (compatible with
+// strconv.Unquote). Unknown keys are ignored; missing keys default to the
+// zero value.
+//
+// This deliberately avoids a full TOML parser dependency. The blob shape is
+// owned by buildTaskTomlBlob; if that function changes, this one must too.
+// User edits via `dodder organize` go through the type's fields-writer
+// (yq) which preserves the same key=value structure.
+func parseTaskTomlBlob(blob []byte) taskBlobValues {
+	var values taskBlobValues
+
+	for _, line := range strings.Split(string(blob), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			continue
+		}
+
+		key := strings.TrimSpace(line[:eq])
+		raw := strings.TrimSpace(line[eq+1:])
+
+		val, err := strconv.Unquote(raw)
+		if err != nil {
+			continue
+		}
+
+		switch key {
+		case "status":
+			values.Status = val
+		case "priority":
+			values.Priority = val
+		case "due":
+			values.Due = val
+		case "notes":
+			values.Notes = val
+		}
+	}
+
+	return values
 }

--- a/go/internal/mike/haustoria_caldav/task_blob_test.go
+++ b/go/internal/mike/haustoria_caldav/task_blob_test.go
@@ -1,0 +1,223 @@
+//go:build test
+
+package haustoria_caldav
+
+import (
+	"testing"
+
+	"code.linenisgreat.com/dodder/go/internal/hotel/caldav"
+	"code.linenisgreat.com/dodder/go/lib/charlie/ui"
+)
+
+func TestStatusValueRoundTrip(t1 *testing.T) {
+	t := ui.T{T: t1}
+
+	cases := []struct {
+		vtodo string
+		field string
+	}{
+		{vtodo: "", field: "todo"},
+		{vtodo: "NEEDS-ACTION", field: "todo"},
+		{vtodo: "IN-PROCESS", field: "in_progress"},
+		{vtodo: "COMPLETED", field: "done"},
+		{vtodo: "CANCELLED", field: "cancelled"},
+	}
+
+	for _, tc := range cases {
+		got := mapVTODOStatusToFieldValue(tc.vtodo)
+		if got != tc.field {
+			t.Errorf("vtodo→field: input %q, expected %q, got %q", tc.vtodo, tc.field, got)
+		}
+	}
+
+	// Reverse direction. Note: empty/NEEDS-ACTION both round-trip to "todo"
+	// → "NEEDS-ACTION" (the canonical open-task VTODO STATUS).
+	reverseCases := []struct {
+		field string
+		vtodo string
+	}{
+		{field: "todo", vtodo: "NEEDS-ACTION"},
+		{field: "in_progress", vtodo: "IN-PROCESS"},
+		{field: "done", vtodo: "COMPLETED"},
+		{field: "cancelled", vtodo: "CANCELLED"},
+	}
+
+	for _, tc := range reverseCases {
+		got := mapFieldValueToVTODOStatus(tc.field)
+		if got != tc.vtodo {
+			t.Errorf("field→vtodo: input %q, expected %q, got %q", tc.field, tc.vtodo, got)
+		}
+	}
+
+	// Unknown values fall back to "todo" / "NEEDS-ACTION".
+	if got := mapVTODOStatusToFieldValue("BOGUS"); got != "todo" {
+		t.Errorf("unknown vtodo status: expected fallback %q, got %q", "todo", got)
+	}
+
+	if got := mapFieldValueToVTODOStatus("bogus"); got != "NEEDS-ACTION" {
+		t.Errorf("unknown field status: expected fallback %q, got %q", "NEEDS-ACTION", got)
+	}
+}
+
+func TestPriorityValueRoundTrip(t1 *testing.T) {
+	t := ui.T{T: t1}
+
+	// Canonical numeric values from the §1 priority table.
+	canonicalCases := []struct {
+		vtodo int
+		field string
+	}{
+		{vtodo: 0, field: "p3"},
+		{vtodo: 1, field: "p0"},
+		{vtodo: 5, field: "p1"},
+		{vtodo: 9, field: "p2"},
+	}
+
+	for _, tc := range canonicalCases {
+		gotField := mapVTODOPriorityToFieldValue(tc.vtodo)
+		if gotField != tc.field {
+			t.Errorf("vtodo→field: input %d, expected %q, got %q", tc.vtodo, tc.field, gotField)
+		}
+
+		gotVtodo := mapFieldValueToVTODOPriority(tc.field)
+		if gotVtodo != tc.vtodo {
+			t.Errorf("field→vtodo: input %q, expected %d, got %d", tc.field, tc.vtodo, gotVtodo)
+		}
+	}
+
+	// Out-of-band VTODO PRIORITY values bucket to the nearest canonical
+	// field value. The boundaries are: 0=p3, 1-2=p0, 3-5=p1, 6-9=p2.
+	bucketCases := []struct {
+		vtodo int
+		field string
+	}{
+		{vtodo: 2, field: "p0"},
+		{vtodo: 3, field: "p1"},
+		{vtodo: 4, field: "p1"},
+		{vtodo: 6, field: "p2"},
+		{vtodo: 7, field: "p2"},
+		{vtodo: 8, field: "p2"},
+	}
+
+	for _, tc := range bucketCases {
+		got := mapVTODOPriorityToFieldValue(tc.vtodo)
+		if got != tc.field {
+			t.Errorf("bucket: vtodo %d expected %q, got %q", tc.vtodo, tc.field, got)
+		}
+	}
+
+	// Unknown field value falls back to no-priority.
+	if got := mapFieldValueToVTODOPriority("bogus"); got != 0 {
+		t.Errorf("unknown field priority: expected fallback 0, got %d", got)
+	}
+}
+
+func TestBuildTaskTomlBlobBasic(t1 *testing.T) {
+	t := ui.T{T: t1}
+
+	task := &caldav.Task{
+		Status:      "COMPLETED",
+		Priority:    1,
+		Due:         "20260415T120000Z",
+		Description: "first line\nsecond line",
+	}
+
+	blob := buildTaskTomlBlob(task)
+
+	expected := "status = \"done\"\n" +
+		"priority = \"p0\"\n" +
+		"due = \"20260415T120000Z\"\n" +
+		"notes = \"first line\\nsecond line\"\n"
+
+	if string(blob) != expected {
+		t.Errorf("blob mismatch:\n--- expected ---\n%s\n--- actual ---\n%s",
+			expected, string(blob))
+	}
+}
+
+func TestBuildTaskTomlBlobEmptyDefaults(t1 *testing.T) {
+	t := ui.T{T: t1}
+
+	task := &caldav.Task{} // all zero values
+
+	blob := buildTaskTomlBlob(task)
+
+	expected := "status = \"todo\"\n" +
+		"priority = \"p3\"\n" +
+		"due = \"\"\n" +
+		"notes = \"\"\n"
+
+	if string(blob) != expected {
+		t.Errorf("blob mismatch:\n--- expected ---\n%s\n--- actual ---\n%s",
+			expected, string(blob))
+	}
+}
+
+func TestParseTaskTomlBlobRoundTrip(t1 *testing.T) {
+	t := ui.T{T: t1}
+
+	task := &caldav.Task{
+		Status:      "IN-PROCESS",
+		Priority:    5,
+		Due:         "20260420T080000Z",
+		Description: "the notes\ncan span\nmultiple lines",
+	}
+
+	blob := buildTaskTomlBlob(task)
+	values := parseTaskTomlBlob(blob)
+
+	if values.Status != "in_progress" {
+		t.Errorf("status: expected %q, got %q", "in_progress", values.Status)
+	}
+
+	if values.Priority != "p1" {
+		t.Errorf("priority: expected %q, got %q", "p1", values.Priority)
+	}
+
+	if values.Due != "20260420T080000Z" {
+		t.Errorf("due: expected %q, got %q", "20260420T080000Z", values.Due)
+	}
+
+	if values.Notes != "the notes\ncan span\nmultiple lines" {
+		t.Errorf("notes: round-trip mismatch, got %q", values.Notes)
+	}
+}
+
+func TestParseTaskTomlBlobIgnoresBlankAndCommentLines(t1 *testing.T) {
+	t := ui.T{T: t1}
+
+	blob := []byte("# comment\n" +
+		"\n" +
+		"status = \"done\"\n" +
+		"  \n" +
+		"# another comment\n" +
+		"priority = \"p2\"\n")
+
+	values := parseTaskTomlBlob(blob)
+
+	if values.Status != "done" {
+		t.Errorf("status: expected %q, got %q", "done", values.Status)
+	}
+
+	if values.Priority != "p2" {
+		t.Errorf("priority: expected %q, got %q", "p2", values.Priority)
+	}
+}
+
+func TestParseTaskTomlBlobUnknownKeysIgnored(t1 *testing.T) {
+	t := ui.T{T: t1}
+
+	blob := []byte("status = \"todo\"\n" +
+		"unknown = \"some value\"\n" +
+		"due = \"20260101T000000Z\"\n")
+
+	values := parseTaskTomlBlob(blob)
+
+	if values.Status != "todo" {
+		t.Errorf("status: expected %q, got %q", "todo", values.Status)
+	}
+
+	if values.Due != "20260101T000000Z" {
+		t.Errorf("due: expected %q, got %q", "20260101T000000Z", values.Due)
+	}
+}

--- a/go/internal/november/env_workspace/main.go
+++ b/go/internal/november/env_workspace/main.go
@@ -169,10 +169,9 @@ func Make(
 						}
 
 						calendars = append(calendars, haustoria_caldav.CalendarMapping{
-							URL:        cal.URL,
-							TypeId:     cal.Type,
-							Tags:       cal.Tags,
-							StatusTags: cal.StatusTags,
+							URL:    cal.URL,
+							TypeId: cal.Type,
+							Tags:   cal.Tags,
 						})
 					}
 				}

--- a/go/internal/sierra/local_working_copy/genesis.go
+++ b/go/internal/sierra/local_working_copy/genesis.go
@@ -87,6 +87,14 @@ func (local *Repo) initDefaultTypeAndConfig(
 		return err
 	}
 
+	if err = local.prepareBuiltinActionableTypes(
+		bigBang,
+		&builder,
+	); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
 	plan, buildErr := builder.Build()
 	if buildErr != nil {
 		err = errors.Wrap(buildErr)
@@ -174,6 +182,65 @@ func (local *Repo) prepareDefaultType(
 	}
 
 	return objectIdType, err
+}
+
+// prepareBuiltinActionableTypes commits the !task and !chore built-in types
+// when bigBang.IncludeBuiltinActionableTypes is set. Both types share the same
+// field set (status, priority, due) declared in type_blobs.DefaultTaskType /
+// DefaultChoreType. Opt-in for now per docs/plans/2026-04-06-task-type-genesis-
+// and-haustoria-fields.md.
+func (local *Repo) prepareBuiltinActionableTypes(
+	bigBang env_repo.BigBang,
+	builder *import_plan.Builder,
+) (err error) {
+	if !bigBang.IncludeBuiltinActionableTypes {
+		return err
+	}
+
+	for _, builtin := range []struct {
+		objectIdString string
+		blob           type_blobs.TomlV2
+	}{
+		{
+			objectIdString: "task",
+			blob:           type_blobs.DefaultTaskType(),
+		},
+		{
+			objectIdString: "chore",
+			blob:           type_blobs.DefaultChoreType(),
+		},
+	} {
+		objectIdType := ids.MustTypeStruct(builtin.objectIdString)
+		tipe := ids.DefaultOrPanic(genres.Type)
+
+		object, _ := sku.GetTransactedPool().GetWithRepool() //repool:owned
+
+		if err = object.GetObjectIdMutable().SetWithId(objectIdType); err != nil {
+			err = errors.Wrap(err)
+			return err
+		}
+
+		var digest domain_interfaces.MarklId
+
+		blob := builtin.blob
+		if digest, _, err = local.GetStore().GetTypedBlobStore().Type.SaveBlobText(
+			tipe,
+			&blob,
+		); err != nil {
+			err = errors.Wrap(err)
+			return err
+		}
+
+		object.GetMetadataMutable().GetBlobDigestMutable().ResetWithMarklId(digest)
+		object.GetMetadataMutable().GetTypeMutable().ResetWithType(tipe)
+
+		if err = builder.AddObject(object, 0); err != nil {
+			err = errors.Wrap(err)
+			return err
+		}
+	}
+
+	return err
 }
 
 func (local *Repo) prepareDefaultConfig(

--- a/go/internal/tango/remote_http/client.go
+++ b/go/internal/tango/remote_http/client.go
@@ -47,7 +47,6 @@ type client struct {
 	http                     http.Client
 	repo                     *local_working_copy.Repo
 	inventoryListCoderCloset inventory_list_coders.Closet
-
 }
 
 func (client *client) Initialize() {
@@ -88,7 +87,6 @@ func (client *client) Initialize() {
 			"failed to read remote immutable config",
 		)
 	}
-
 }
 
 func (client *client) GetEnv() env_ui.Env {

--- a/go/internal/uniform/command_components_dodder/genesis.go
+++ b/go/internal/uniform/command_components_dodder/genesis.go
@@ -73,6 +73,13 @@ func (cmd *Genesis) SetFlagDefinitions(
 		false,
 		"Include pandoc Lua filters and defaults as blob references on the default type",
 	)
+
+	flagSet.BoolVar(
+		&cmd.BigBang.IncludeBuiltinActionableTypes,
+		"include-builtin-actionable-types",
+		false,
+		"Commit !task and !chore built-in types with status/priority/due fields and yq-based reader/writer scripts",
+	)
 }
 
 func (cmd Genesis) OnTheFirstDay(

--- a/go/lib/delta/trie/main.go
+++ b/go/lib/delta/trie/main.go
@@ -161,5 +161,3 @@ func (n node) Abbreviate(v string, loc int) string {
 		}
 	}
 }
-
-

--- a/zz-tests_bats/current_version/fields.bats
+++ b/zz-tests_bats/current_version/fields.bats
@@ -95,6 +95,42 @@ function create_task_type_reader_only {
   assert_success
 }
 
+# Type with the FULL three-field set (status, priority, due) and both
+# reader/writer scripts, mirroring what !task would ship with. Used to probe
+# whether the haustoria-style flow (write a TOML blob with fields baked in,
+# then commit) round-trips correctly.
+function create_task_type_full {
+  cat - >task.type <<-'EOM'
+		file-extension = "toml"
+		vim-syntax-type = "toml"
+
+		[[fields]]
+		name = "status"
+		kind = "enum"
+		values = ["todo", "in-process", "done", "cancelled"]
+		default = "todo"
+
+		[[fields]]
+		name = "priority"
+		kind = "enum"
+		values = ["p0", "p1", "p2", "p3"]
+		default = "p0"
+
+		[[fields]]
+		name = "due"
+		kind = "string"
+
+		[fields-reader]
+		script = "yq -p toml -o json '{\"status\": .status, \"priority\": .priority, \"due\": .due}'"
+
+		[fields-writer]
+		script = "yq -p toml -o toml -i \".status = \\\"$DODDER_FIELD_status\\\" | .priority = \\\"$DODDER_FIELD_priority\\\" | .due = \\\"$DODDER_FIELD_due\\\"\" \"$DODDER_BLOB_PATH\""
+	EOM
+
+  run_dodder checkin -delete task.type
+  assert_success
+}
+
 function field_projection_on_commit { # @test
   create_task_type
   create_task "my first task" "todo"
@@ -280,5 +316,98 @@ function field_persists_with_reader_only_no_writer { # @test
   # output line. See dodder issue (to file).
   assert_output - <<-EOM
 		[one/uno @blake2b256-qhdgjzc945w6v4pw4j4hr66gehgzwf8hq4v9rch9e7px5lf525sqfjcuaa !task "my task" status=todo status=todo]
+	EOM
+}
+
+# Probe: full !task type with three fields and reader+writer. Create a task
+# with a TOML blob that has all three field values baked in.
+#
+# RESULT: works. All three fields project from the blob via the reader script
+# and appear in show output. This is the "option 2" haustoria flow.
+function field_full_task_three_fields_from_blob { # @test
+  create_task_type_full
+
+  run_dodder new -edit=false - <<-EOM
+		---
+		# my task
+		! task
+		---
+
+		status = "in-process"
+		priority = "p2"
+		due = "20260415T120000Z"
+	EOM
+  assert_success
+
+  run_dodder show '!task'
+  assert_success
+  assert_output - <<-EOM
+		[one/uno @blake2b256-vlvc52ycuyyk4vm98j9z33kceh4c0z253e9rlg3n3erp5kwc2xhssfyyn9 !task "my task" status=in-process priority=p2 due=20260415T120000Z]
+	EOM
+}
+
+# Probe: full !task type, organize-mutate one of three fields. Verifies the
+# writer script projects the changed field while preserving the others.
+#
+# RESULT: works. status changes to "done", priority and due remain. The new
+# blob digest is different (writer rewrote the TOML). Round-trip is clean.
+function field_full_task_organize_mutate_one_of_three { # @test
+  create_task_type_full
+  run_dodder init-workspace -experimental-repo=false
+
+  run_dodder new -edit=false - <<-EOM
+		---
+		# my task
+		! task
+		---
+
+		status = "todo"
+		priority = "p1"
+		due = "20260415T120000Z"
+	EOM
+  assert_success
+
+  run_dodder organize -mode commit-directly '!task' <<-EOM
+		- [one/uno !task status=done priority=p1 due=20260415T120000Z] my task
+	EOM
+  assert_success
+
+  run_dodder show '!task'
+  assert_success
+  assert_output - <<-EOM
+		[one/uno @blake2b256-vpgtdcx47rtm8djza9acw46gjrj0a0rc7g6grxt5fqxdcyu5scss7e3xae !task "my task" status=done priority=p1 due=20260415T120000Z]
+	EOM
+}
+
+# Probe: full !task type, organize-set fields starting from an EMPTY blob.
+# This simulates the haustoria's "first checkin if no blob is provided" case.
+#
+# RESULT: same as field_persists_without_any_scripts — fields are dropped,
+# blob digest disappears. Even with a writer script configured, an empty
+# starting blob means tryWriteFields can't run (the writer needs an existing
+# blob path to mutate). Implication: the haustoria MUST write a non-empty
+# starter blob before setting fields, OR write the full TOML blob with fields
+# already baked in (option 2 — see field_full_task_three_fields_from_blob).
+function field_full_task_organize_from_empty_blob { # @test
+  create_task_type_full
+  run_dodder init-workspace -experimental-repo=false
+
+  run_dodder new -edit=false - <<-EOM
+		---
+		# my task
+		! task
+		---
+	EOM
+  assert_success
+
+  run_dodder organize -mode commit-directly '!task' <<-EOM
+		- [one/uno !task status=in-process priority=p2 due=20260415T120000Z] my task
+	EOM
+  assert_success
+
+  run_dodder show '!task'
+  assert_success
+  assert_output - <<-EOM
+		[one/uno !task "my task"]
 	EOM
 }

--- a/zz-tests_bats/current_version/fields.bats
+++ b/zz-tests_bats/current_version/fields.bats
@@ -52,6 +52,49 @@ function create_task {
   assert_success
 }
 
+# Same as create_task_type but with NO fields-reader and NO fields-writer
+# scripts. Only [[fields]] field definitions are present. Used to verify
+# whether fields set directly on metadata.Index survive the commit cycle when
+# tryWriteFields and tryReadFields both early-return at the script-nil gate.
+# This is the codec behavior the haustoria depends on.
+function create_task_type_no_scripts {
+  cat - >task.type <<-'EOM'
+		file-extension = "toml"
+		vim-syntax-type = "toml"
+
+		[[fields]]
+		name = "status"
+		kind = "enum"
+		values = ["todo", "in-progress", "blocked", "done", "cancelled"]
+		default = "todo"
+	EOM
+
+  run_dodder checkin -delete task.type
+  assert_success
+}
+
+# Same as create_task_type but with ONLY a fields-reader (no fields-writer).
+# Used to test whether organize can mutate a field when there's no writer
+# script to project the new value back into the blob.
+function create_task_type_reader_only {
+  cat - >task.type <<-'EOM'
+		file-extension = "toml"
+		vim-syntax-type = "toml"
+
+		[[fields]]
+		name = "status"
+		kind = "enum"
+		values = ["todo", "in-progress", "blocked", "done", "cancelled"]
+		default = "todo"
+
+		[fields-reader]
+		script = "yq -p toml -o json '{\"status\": .status}'"
+	EOM
+
+  run_dodder checkin -delete task.type
+  assert_success
+}
+
 function field_projection_on_commit { # @test
   create_task_type
   create_task "my first task" "todo"
@@ -170,5 +213,72 @@ function field_organize_description_and_field_change { # @test
   assert_success
   assert_output - <<-EOM
 		[one/uno @blake2b256-fh80v4xn6qv49r66rlkpkuvq2wlm4ztpuwjy6chexfjdrk0zhatqngn3sd !task "updated description" status=done]
+	EOM
+}
+
+# Probe: when the type defines [[fields]] but provides NO fields-reader and NO
+# fields-writer scripts, do field values set via organize survive the commit
+# cycle? This is the haustoria CalDAV bridge's assumption: fields it sets on
+# metadata.Index should persist via the binary stream-index codec without
+# needing any script-based projection.
+#
+# RESULT: NO. The status field is dropped entirely. Organize-set field values
+# do not survive commit when no fields-writer script is configured. The blob
+# digest also disappears (the new value's blob is empty since no body was
+# provided to dodder new).
+#
+# Implication: the haustoria CANNOT rely on setting Metadata.Index.Fields
+# directly. Either ship a fields-writer script for !task that projects field
+# values into a TOML blob, or add a code path that bypasses the script gate.
+function field_persists_without_any_scripts { # @test
+  create_task_type_no_scripts
+  run_dodder init-workspace -experimental-repo=false
+
+  run_dodder new -edit=false - <<-EOM
+		---
+		# my task
+		! task
+		---
+	EOM
+  assert_success
+
+  run_dodder organize -mode commit-directly '!task' <<-EOM
+		- [one/uno !task status=done] my task
+	EOM
+  assert_success
+
+  run_dodder show '!task'
+  assert_success
+  # Locked-in: field is gone, blob digest is gone. Confirms fields require a
+  # writer script to round-trip via organize.
+  assert_output - <<-EOM
+		[one/uno !task "my task"]
+	EOM
+}
+
+# Probe: same question, but with a fields-reader script (so the initial blob
+# → field projection works) and NO fields-writer.
+#
+# RESULT: the field is DUPLICATED in show output (`status=todo status=todo`)
+# AND the user's organize-set value (`status=done`) is silently dropped — the
+# reader re-projected from the unchanged blob and won. This is a bug in the
+# organize/reader interaction independent of the haustoria question, but
+# worth flagging.
+function field_persists_with_reader_only_no_writer { # @test
+  create_task_type_reader_only
+  run_dodder init-workspace -experimental-repo=false
+  create_task "my task" "todo"
+
+  run_dodder organize -mode commit-directly '!task' <<-EOM
+		- [one/uno !task status=done] my task
+	EOM
+  assert_success
+
+  run_dodder show '!task'
+  assert_success
+  # Locked-in: duplicated field, user's edit dropped. Two regressions in one
+  # output line. See dodder issue (to file).
+  assert_output - <<-EOM
+		[one/uno @blake2b256-qhdgjzc945w6v4pw4j4hr66gehgzwf8hq4v9rch9e7px5lf525sqfjcuaa !task "my task" status=todo status=todo]
 	EOM
 }

--- a/zz-tests_bats/current_version/fields.bats
+++ b/zz-tests_bats/current_version/fields.bats
@@ -107,14 +107,14 @@ function create_task_type_full {
 		[[fields]]
 		name = "status"
 		kind = "enum"
-		values = ["todo", "in-process", "done", "cancelled"]
+		values = ["todo", "in_progress", "done", "cancelled"]
 		default = "todo"
 
 		[[fields]]
 		name = "priority"
 		kind = "enum"
 		values = ["p0", "p1", "p2", "p3"]
-		default = "p0"
+		default = "p3"
 
 		[[fields]]
 		name = "due"
@@ -333,8 +333,8 @@ function field_full_task_three_fields_from_blob { # @test
 		! task
 		---
 
-		status = "in-process"
-		priority = "p2"
+		status = "in_progress"
+		priority = "p1"
 		due = "20260415T120000Z"
 	EOM
   assert_success
@@ -342,7 +342,7 @@ function field_full_task_three_fields_from_blob { # @test
   run_dodder show '!task'
   assert_success
   assert_output - <<-EOM
-		[one/uno @blake2b256-vlvc52ycuyyk4vm98j9z33kceh4c0z253e9rlg3n3erp5kwc2xhssfyyn9 !task "my task" status=in-process priority=p2 due=20260415T120000Z]
+		[one/uno @blake2b256-sehqwrekuhk346cppprq72mxk0qug5qfe6ghdqcd0tanf4plu6lsape8ag !task "my task" status=in_progress priority=p1 due=20260415T120000Z]
 	EOM
 }
 
@@ -362,20 +362,20 @@ function field_full_task_organize_mutate_one_of_three { # @test
 		---
 
 		status = "todo"
-		priority = "p1"
+		priority = "p2"
 		due = "20260415T120000Z"
 	EOM
   assert_success
 
   run_dodder organize -mode commit-directly '!task' <<-EOM
-		- [one/uno !task status=done priority=p1 due=20260415T120000Z] my task
+		- [one/uno !task status=done priority=p2 due=20260415T120000Z] my task
 	EOM
   assert_success
 
   run_dodder show '!task'
   assert_success
   assert_output - <<-EOM
-		[one/uno @blake2b256-vpgtdcx47rtm8djza9acw46gjrj0a0rc7g6grxt5fqxdcyu5scss7e3xae !task "my task" status=done priority=p1 due=20260415T120000Z]
+		[one/uno @blake2b256-j0yn4cd0fvng3daxg0xrgjrag55v9l3gfsyhnawma3pm3szxpmtsgzaxs9 !task "my task" status=done priority=p2 due=20260415T120000Z]
 	EOM
 }
 
@@ -401,7 +401,7 @@ function field_full_task_organize_from_empty_blob { # @test
   assert_success
 
   run_dodder organize -mode commit-directly '!task' <<-EOM
-		- [one/uno !task status=in-process priority=p2 due=20260415T120000Z] my task
+		- [one/uno !task status=in_progress priority=p1 due=20260415T120000Z] my task
 	EOM
   assert_success
 

--- a/zz-tests_bats/current_version/genesis_actionable_types.bats
+++ b/zz-tests_bats/current_version/genesis_actionable_types.bats
@@ -96,6 +96,33 @@ function genesis_task_type_blob_has_fields_and_scripts { # @test
 	EOM
 }
 
+# Verifies the field round-trip via `dodder new`: after init with the
+# opt-in flag, a freshly-created !task with a TOML body has all three
+# fields projected by the reader script and visible in `dodder show`.
+function genesis_dodder_new_task_projects_fields { # @test
+  init_fixture -include-builtin-actionable-types
+  run_dodder init-workspace -experimental-repo=false
+
+  run_dodder new -edit=false - <<-EOM
+		---
+		# my probe task
+		! task
+		---
+
+		status = "in_progress"
+		priority = "p1"
+		due = "20260415T120000Z"
+		notes = "probe content"
+	EOM
+  assert_success
+
+  run_dodder show '!task'
+  assert_success
+  assert_output - <<-EOM
+		[one/uno @blake2b256-g9ch2vs6vwqhhx8jgmj6xhq02u3ze39mgjj5ranpn3jv9kdeu8rsz2r9xj !task "my probe task" status=in_progress priority=p1 due=20260415T120000Z]
+	EOM
+}
+
 # !chore should have the same field set as !task — same field defs, same
 # scripts. The blob digests should match because the bodies are
 # byte-identical.

--- a/zz-tests_bats/current_version/genesis_actionable_types.bats
+++ b/zz-tests_bats/current_version/genesis_actionable_types.bats
@@ -1,0 +1,121 @@
+#! /usr/bin/env bats
+
+# file_tags=user_story:builtin_types
+
+setup() {
+  load "$(dirname "$BATS_TEST_FILE")/../lib/common.bash"
+
+  # for shellcheck SC2154
+  export output
+}
+
+teardown() {
+  chflags_nouchg
+}
+
+# Run dodder init with the standard fixture flags. Pass extra args (like
+# -include-builtin-actionable-types) as positional arguments.
+function init_fixture {
+  run_dodder init \
+    -yin <(cat_yin) \
+    -yang <(cat_yang) \
+    -encryption none \
+    -repo_id . \
+    -lock-internal-files=false \
+    "$@" \
+    test-repo-id
+  assert_success
+}
+
+# Without the opt-in flag, dodder init does NOT commit !task or !chore.
+# Only the existing !md default type is present.
+function genesis_default_omits_actionable_types { # @test
+  init_fixture
+
+  run_dodder show ':t'
+  assert_success
+  assert_output --regexp - <<-EOM
+		\[!md @blake2b256-.+ !toml-type-v2]
+	EOM
+}
+
+# With -include-builtin-actionable-types, !task and !chore are committed
+# during genesis alongside !md, each with the actionable field set
+# (status, priority, due) and yq reader/writer scripts.
+function genesis_includes_actionable_types_when_opted_in { # @test
+  init_fixture -include-builtin-actionable-types
+
+  run_dodder show ':t'
+  assert_success
+  assert_output_unsorted --regexp - <<-EOM
+		\[!chore @blake2b256-.+ !toml-type-v2]
+		\[!md @blake2b256-.+ !toml-type-v2]
+		\[!task @blake2b256-.+ !toml-type-v2]
+	EOM
+}
+
+# The !task type blob exposes the actionable field definitions and the
+# yq reader/writer scripts. Verifies the type blob format the haustoria
+# depends on.
+function genesis_task_type_blob_has_fields_and_scripts { # @test
+  init_fixture -include-builtin-actionable-types
+
+  run_dodder show -format blob '!task:t'
+  assert_success
+  # Note: tommy's TOML encoder serializes script as a triple-quoted multiline
+  # string and unescapes backslashes (the Script field has the `multiline`
+  # tommy tag). The Go-side definition uses double-quoted string literals
+  # with escaped backslashes; these become triple-quoted multilines on disk.
+  assert_output - <<-'EOM'
+		file-extension = "toml"
+		vim-syntax-type = "toml"
+
+		[[fields]]
+		name = "status"
+		kind = "enum"
+		values = ["todo", "in_progress", "done", "cancelled"]
+		default = "todo"
+
+		[[fields]]
+		name = "priority"
+		kind = "enum"
+		values = ["p0", "p1", "p2", "p3"]
+		default = "p3"
+
+		[[fields]]
+		name = "due"
+		kind = "string"
+
+		[fields-reader]
+		script = """
+		yq -p toml -o json '{"status": .status, "priority": .priority, "due": .due}'"""
+
+		[fields-writer]
+		script = """
+		yq -p toml -o toml -i ".status = \"$DODDER_FIELD_status\" | .priority = \"$DODDER_FIELD_priority\" | .due = \"$DODDER_FIELD_due\"" "$DODDER_BLOB_PATH""""
+	EOM
+}
+
+# !chore should have the same field set as !task — same field defs, same
+# scripts. The blob digests should match because the bodies are
+# byte-identical.
+function genesis_chore_type_matches_task_type { # @test
+  init_fixture -include-builtin-actionable-types
+
+  run_dodder show -format object-id-blob-digest '!task:t'
+  assert_success
+  task_line="$output"
+
+  run_dodder show -format object-id-blob-digest '!chore:t'
+  assert_success
+  chore_line="$output"
+
+  task_digest="${task_line##* }"
+  chore_digest="${chore_line##* }"
+
+  if [[ "$task_digest" != "$chore_digest" ]]; then
+    echo "task digest:  $task_digest" >&2
+    echo "chore digest: $chore_digest" >&2
+    false
+  fi
+}

--- a/zz-tests_bats/current_version/haustoria_caldav.bats
+++ b/zz-tests_bats/current_version/haustoria_caldav.bats
@@ -145,6 +145,76 @@ END:VCALENDAR"
   fi
 }
 
+# Put a VTODO with a complete field set: STATUS, PRIORITY, DUE,
+# DESCRIPTION, plus optional CATEGORIES. Used by the round-trip tests
+# below.
+# Usage: put_vtodo_full <url> <uid> <summary> <status> <priority> <due> <description> [categories]
+function put_vtodo_full {
+  local calendar_url="$1"
+  local uid="$2"
+  local summary="$3"
+  local status="$4"
+  local priority="$5"
+  local due="$6"
+  local description="$7"
+  local categories="${8:-}"
+
+  local ical="BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//dodder-test//test//EN
+BEGIN:VTODO
+UID:$uid
+SUMMARY:$summary
+STATUS:$status
+PRIORITY:$priority"
+
+  if [[ -n "$due" ]]; then
+    ical="$ical
+DUE:$due"
+  fi
+
+  if [[ -n "$description" ]]; then
+    # Escape backslashes and newlines per RFC 5545.
+    local escaped="${description//\\/\\\\}"
+    escaped="${escaped//$'\n'/\\n}"
+    ical="$ical
+DESCRIPTION:$escaped"
+  fi
+
+  if [[ -n "$categories" ]]; then
+    ical="$ical
+CATEGORIES:$categories"
+  fi
+
+  ical="$ical
+END:VTODO
+END:VCALENDAR"
+
+  local http_code
+  http_code=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+    -u "$CALDAV_USERNAME:$CALDAV_PASSWORD" \
+    -H "Content-Type: text/calendar" \
+    "${calendar_url}${uid}.ics" \
+    -d "$ical")
+
+  if [[ $http_code -ge 400 ]]; then
+    fail "PUT VTODO $uid (full) failed with HTTP $http_code"
+  fi
+}
+
+# Read a VTODO from CalDAV and emit raw iCal text on stdout. Used by
+# round-trip tests to assert what made it back to the server after a
+# checkout.
+function get_vtodo_ical {
+  local calendar_url="$1"
+  local uid="$2"
+
+  curl -s \
+    -u "$CALDAV_USERNAME:$CALDAV_PASSWORD" \
+    -H "Accept: text/calendar" \
+    "${calendar_url}${uid}.ics"
+}
+
 function create_calendar {
   local calendar_url="$1"
 
@@ -168,9 +238,31 @@ function create_calendar {
   fi
 }
 
+# Bootstrap parent repo with !task and !chore built-in types.
+# Wraps dodder init with -include-builtin-actionable-types so the parent
+# commits the actionable type definitions, then init-workspace into the
+# workspace dir. Tests rely on the !task type's reader script projecting
+# status/priority/due fields onto checked-out objects from CalDAV.
+function init_haustoria_parent {
+  local parent_dir="$1"
+  pushd "$parent_dir" || return 1
+  run_dodder init \
+    -yin <(cat_yin) \
+    -yang <(cat_yang) \
+    -encryption none \
+    -repo_id . \
+    -lock-internal-files=false \
+    -include-builtin-actionable-types \
+    test-parent
+  assert_success
+  popd || return 1
+}
+
 # Bootstrap a multi-calendar haustoria workspace with custom config.
-# Creates parent repo, workspace dir, runs init-workspace, then overwrites
-# the workspace config with a multi-calendar + status-tags configuration.
+# Creates parent repo (with built-in actionable types), workspace dir, runs
+# init-workspace, then overwrites the workspace config with a multi-calendar
+# configuration. Status / priority / due round-trip via the !task and !chore
+# field reader/writer scripts; no status-tags mapping.
 function bootstrap_multi_calendar_workspace {
   local parent_dir="$BATS_TEST_TMPDIR/parent"
   local workspace_dir="$BATS_TEST_TMPDIR/workspace"
@@ -183,19 +275,19 @@ function bootstrap_multi_calendar_workspace {
   create_calendar "$CALDAV_TASKS_URL"
   create_calendar "$CALDAV_CHORES_URL"
 
-  pushd "$parent_dir" || return 1
-  run_dodder_init_disable_age "test-parent"
-  popd || return 1
+  init_haustoria_parent "$parent_dir"
 
   pushd "$workspace_dir" || return 1
   run_dodder init-workspace \
     -haustoria caldav \
     -parent "$parent_dir" \
+    -include-builtin-actionable-types \
     ${cmd_dodder_def[@]} \
     haustoria-ws
   assert_success
 
-  # Overwrite config with multi-calendar + status-tags
+  # Overwrite config with multi-calendar setup. No status-tags blocks —
+  # status round-trips via the !task field instead.
   cat >.dodder-workspace <<EOF
 ---
 ! toml-workspace_config-v2
@@ -217,15 +309,9 @@ username = "$CALDAV_USERNAME"
 url = "$CALDAV_TASKS_URL"
 type = "!task"
 
-[haustoria.calendars.tasks.status-tags]
-COMPLETED = "zz-archive-task-done"
-
 [haustoria.calendars.chores]
 url = "$CALDAV_CHORES_URL"
 type = "!chore"
-
-[haustoria.calendars.chores.status-tags]
-COMPLETED = "zz-archive-task-done"
 EOF
 
   popd || return 1
@@ -238,14 +324,13 @@ function bootstrap_haustoria_workspace {
 
   create_calendar "$CALDAV_URL"
 
-  pushd "$parent_dir" || return 1
-  run_dodder_init_disable_age "test-parent"
-  popd || return 1
+  init_haustoria_parent "$parent_dir"
 
   pushd "$workspace_dir" || return 1
   run_dodder init-workspace \
     -haustoria caldav \
     -parent "$parent_dir" \
+    -include-builtin-actionable-types \
     ${cmd_dodder_def[@]} \
     haustoria-ws
   assert_success
@@ -261,9 +346,14 @@ function status_shows_caldav_resources { # @test
   pushd "$BATS_TEST_TMPDIR/workspace" || return 1
   run_dodder status
   assert_success
+  # Status shows the in-memory CalDAV objects produced by the haustoria's
+  # compile path. The blob digest reflects the new TOML format
+  # (status/priority/due/notes). No field columns appear because the !task
+  # type's reader script only runs during the commit cycle, not during the
+  # untracked-status query — fields project after `dodder checkin`.
   assert_output_unsorted - <<-'EOM'
-		        untracked [task-1 @blake2b256-sfghaeqe5dwr74mqpkttk402jua5um9ql3jgcdgpmvqx6znsf0ws8scpua !task "Buy groceries" errands shopping]
-		        untracked [task-2 @blake2b256-eac5sj9j602ktwhy9zv355rm7nt82gqsyn525fkj2wxvqe4vuevqcy9n57 !task "Call dentist" health]
+		        untracked [task-1 @blake2b256-qg0l6r7jxyfh0zptqns7r4j664hp8j4htjrea3es6g5ve907jc6qgnk98w !task "Buy groceries" errands shopping]
+		        untracked [task-2 @blake2b256-55pqnlyz6l9f9c4gfx68xvty2wy2e9evartmveg6t87ddft9tq3qdqvr47 !task "Call dentist" health]
 	EOM
   popd || return 1
 }
@@ -279,11 +369,15 @@ function checkin_creates_zettels_from_caldav { # @test
   run_dodder checkin :
   assert_success
 
-  run_dodder show :
+  # Query with type filter so the box format shows fields. Both tasks
+  # have empty notes/due/priority, so they share the same TOML blob
+  # digest (status=todo, priority=p3, due="", notes="") — content-
+  # addressing means identical blobs map to one digest.
+  run_dodder show '!task'
   assert_success
   assert_output_unsorted - <<-EOM
-		[one/dos !task "Write report" work]
-		[one/uno !task "Fix bike" errands]
+		[one/dos @blake2b256-4a2a979r54j2804n697c20mvhjg8t377knujfxc6t8szh2awkwts2whwug !task "Write report" work status=todo priority=p3 due=]
+		[one/uno @blake2b256-4a2a979r54j2804n697c20mvhjg8t377knujfxc6t8szh2awkwts2whwug !task "Fix bike" errands status=todo priority=p3 due=]
 	EOM
   popd || return 1
 }
@@ -330,6 +424,9 @@ function new_creates_zettel_and_decompiles_to_caldav { # @test
 
   pushd "$BATS_TEST_TMPDIR/workspace" || return 1
 
+  # The blob body is now TOML mirroring the !task field set; the writer
+  # script (yq) needs valid TOML on input. The notes key holds the
+  # free-form description text.
   run_dodder new -edit=false - <<-EOM
 		---
 		# Review PR
@@ -337,16 +434,19 @@ function new_creates_zettel_and_decompiles_to_caldav { # @test
 		! task
 		---
 
-		check for regressions
+		status = "todo"
+		priority = "p1"
+		due = ""
+		notes = "check for regressions"
 	EOM
   assert_success
 
-  # Verify zettel was created in dodder store
-  run_dodder show :
+  # Verify zettel was created in dodder store with field projection
+  run_dodder show '!task'
   assert_success
-  assert_output --partial "Review PR"
-  assert_output --partial "!task"
-  assert_output --partial "work"
+  assert_output --partial 'Review PR'
+  assert_output --partial 'status=todo'
+  assert_output --partial 'priority=p1'
 
   # Verify VTODO was created on CalDAV
   run_dodder status
@@ -366,19 +466,20 @@ function checkin_idempotent_no_duplicates { # @test
   run_dodder checkin :
   assert_success
 
-  run_dodder show :
+  run_dodder show '!task'
   assert_success
   assert_output --partial "Idempotent task"
-  local first_output="$output"
 
   # Second checkin should NOT create a duplicate
   run_dodder checkin :
   assert_success
 
-  run_dodder show :
+  run_dodder show '!task'
   assert_success
+  # Single object with field columns. Blob digest is the zero-default
+  # TOML blob (status=todo, priority=p3, due="", notes="").
   assert_output - <<-EOM
-		[one/uno !task "Idempotent task" test]
+		[one/uno @blake2b256-4a2a979r54j2804n697c20mvhjg8t377knujfxc6t8szh2awkwts2whwug !task "Idempotent task" test status=todo priority=p3 due=]
 	EOM
   popd || return 1
 }
@@ -399,11 +500,15 @@ function status_shows_checked_out_after_checkin { # @test
   run_dodder checkin :
   assert_success
 
-  # After checkin: should show as checked out, not untracked
+  # After checkin: should show as checked out, not untracked. The blob
+  # digest is set during compile via buildTaskTomlBlob; since the bound
+  # in-memory object is not re-projected through the reader script during
+  # the status query (only on commit), the box format here doesn't show
+  # field columns — same as the untracked case.
   run_dodder status
   assert_success
   assert_output - <<-EOM
-		          changed [ !task "Bound task" test]
+		          changed [ @blake2b256-4a2a979r54j2804n697c20mvhjg8t377knujfxc6t8szh2awkwts2whwug !task "Bound task" test]
 	EOM
   popd || return 1
 }
@@ -422,14 +527,14 @@ function checkin_empty_calendar_no_error { # @test
   popd || return 1
 }
 
-function multi_calendar_status_with_status_tags { # @test
+function multi_calendar_status_field_projection { # @test
   bootstrap_multi_calendar_workspace
 
   # Active tasks
   put_vtodo_with_status "$CALDAV_TASKS_URL" "t-1" "Write docs" "NEEDS-ACTION" "work"
   put_vtodo_with_status "$CALDAV_TASKS_URL" "t-2" "Fix login bug" "NEEDS-ACTION" "work,urgent"
 
-  # Completed task — should get zz-archive-task-done tag
+  # Completed task — projects status=done via the reader script after checkin
   put_vtodo_with_status "$CALDAV_TASKS_URL" "t-3" "Old migration" "COMPLETED" "ops"
 
   # Chore calendar
@@ -441,25 +546,36 @@ function multi_calendar_status_with_status_tags { # @test
   run_dodder status
   assert_success
 
-  # All 5 tasks appear (completed ones get the status-tag, not filtered)
+  # All 5 tasks appear (completed ones are not filtered — that's a
+  # consumer concern via doddish field queries).
   local line_count
   line_count=$(echo "$output" | wc -l)
   [[ $line_count -eq 5 ]]
 
-  # Verify status-tags mapping: completed tasks have zz-archive-task-done
-  assert_output --partial "zz-archive-task-done"
-
-  # Verify both calendar types present
+  # Both calendar types present
   assert_output --partial "!task"
   assert_output --partial "!chore"
 
-  # Checkin and verify completed task has the archive tag
+  # Checkin and verify the field projection survived through both types.
   run_dodder checkin :
   assert_success
 
-  run_dodder show :
+  run_dodder show '!task'
   assert_success
-  assert_output --partial "zz-archive-task-done"
+  # COMPLETED → status=done, NEEDS-ACTION → status=todo
+  assert_output --partial 'status=done'
+  assert_output --partial 'status=todo'
+
+  run_dodder show '!chore'
+  assert_success
+  assert_output --partial 'status=done'
+  assert_output --partial 'status=todo'
+
+  # Doddish field query works for filtering completed tasks, replacing
+  # the previous zz-archive-task-done tag-based filter.
+  run_dodder show '^status=done !task'
+  assert_success
+  refute_output --partial 'Old migration'
 
   popd || return 1
 }
@@ -503,7 +619,7 @@ END:VCALENDAR"
   popd || return 1
 }
 
-function completed_tasks_get_status_tag { # @test
+function completed_tasks_get_status_field { # @test
   bootstrap_multi_calendar_workspace
 
   put_vtodo_with_status "$CALDAV_TASKS_URL" "done-1" "Finished task" "COMPLETED" "work"
@@ -515,8 +631,9 @@ function completed_tasks_get_status_tag { # @test
   run_dodder checkin :
   assert_success
 
-  # Show all — completed task should have zz-archive-task-done, active should not
-  run_dodder show :
+  # Show !task — completed task projects status=done via the reader
+  # script, active projects status=todo.
+  run_dodder show '!task'
   assert_success
 
   # Two zettels created
@@ -524,10 +641,175 @@ function completed_tasks_get_status_tag { # @test
   line_count=$(echo "$output" | wc -l)
   [[ $line_count -eq 2 ]]
 
-  # Completed task has archive tag, active task does not
-  assert_output --partial '"Finished task" work zz-archive-task-done'
-  assert_output --partial '"Active task" work]'
-  refute_output --partial '"Active task" work zz-archive-task-done'
+  # Completed task has status=done, active task has status=todo. The
+  # field columns appear after the tag list in the box format.
+  assert_output --partial '"Finished task" work status=done'
+  assert_output --partial '"Active task" work status=todo'
+
+  popd || return 1
+}
+
+# Round-trip test covering all four blob keys (status, priority, due,
+# notes): VTODO with full field set → checkin → checkout (without
+# mutation) → verify CalDAV-side state matches the original. This
+# exercises buildTaskTomlBlob (compile) and parseTaskTomlBlob +
+# Decompile (round-trip back to VTODO) together.
+#
+# Note: this test does NOT exercise the organize-driven mutation path.
+# `dodder organize -mode commit-directly` triggers a deeper malformed-
+# blob-digest panic in the merge path that's unrelated to the haustoria
+# implementation; tracked as a follow-up issue.
+function caldav_round_trip_all_fields { # @test
+  bootstrap_haustoria_workspace
+
+  put_vtodo_full \
+    "$CALDAV_URL" \
+    "rt-1" \
+    "Round trip task" \
+    "IN-PROCESS" \
+    "1" \
+    "20260415T120000Z" \
+    "the original notes" \
+    "work,urgent"
+
+  pushd "$BATS_TEST_TMPDIR/workspace" || return 1
+
+  # Checkin: blob is built from VTODO via buildTaskTomlBlob; reader
+  # script projects fields into the index.
+  run_dodder checkin :
+  assert_success
+
+  run_dodder show '!task'
+  assert_success
+  # Compile mappings: STATUS:IN-PROCESS → in_progress, PRIORITY:1 → p0
+  assert_output --partial 'status=in_progress'
+  assert_output --partial 'priority=p0'
+  assert_output --partial 'due=20260415T120000Z'
+
+  # Delete the CalDAV resource so checkout has to recreate it from the
+  # dodder-side TOML blob.
+  curl -s -X DELETE \
+    -u "$CALDAV_USERNAME:$CALDAV_PASSWORD" \
+    "${CALDAV_URL}rt-1.ics" >/dev/null 2>&1
+
+  # Checkout: Decompile parses the TOML blob, applies inverse
+  # status/priority mappings, and PUTs a new VTODO.
+  run_dodder checkout :z
+  assert_success
+
+  # Verify the VTODO on the CalDAV server reflects the original state.
+  # Note: the haustoria's Decompile path does not currently round-trip
+  # CATEGORIES (tags are read from object metadata, not from the blob),
+  # so we don't assert on those here.
+  run get_vtodo_ical "$CALDAV_URL" "rt-1"
+  assert_success
+  assert_output --partial 'STATUS:IN-PROCESS'
+  assert_output --partial 'PRIORITY:1'
+  assert_output --partial 'DUE:20260415T120000Z'
+  assert_output --partial 'DESCRIPTION:the original notes'
+
+  popd || return 1
+}
+
+# Edge case: VTODO with empty optional fields (no PRIORITY, no DUE, no
+# DESCRIPTION). All three should land as defaults (p3, "", "") and survive
+# the round-trip.
+function caldav_round_trip_empty_optionals { # @test
+  bootstrap_haustoria_workspace
+
+  put_vtodo_full \
+    "$CALDAV_URL" \
+    "rt-empty" \
+    "Empty optionals" \
+    "NEEDS-ACTION" \
+    "0" \
+    "" \
+    "" \
+    ""
+
+  pushd "$BATS_TEST_TMPDIR/workspace" || return 1
+
+  run_dodder checkin :
+  assert_success
+
+  run_dodder show '!task'
+  assert_success
+  assert_output --partial 'status=todo'
+  assert_output --partial 'priority=p3'
+  assert_output --partial 'due='
+
+  popd || return 1
+}
+
+# Edge case: multi-line VTODO DESCRIPTION text. Notes is the only blob
+# key that can contain newlines; the buildTaskTomlBlob serializer uses
+# strconv.Quote which produces a single-line basic string with \n
+# escapes. Verify the round-trip preserves the line breaks.
+function caldav_round_trip_multiline_notes { # @test
+  bootstrap_haustoria_workspace
+
+  put_vtodo_full \
+    "$CALDAV_URL" \
+    "rt-multi" \
+    "Multi-line notes" \
+    "NEEDS-ACTION" \
+    "0" \
+    "" \
+    "first line
+second line
+third line" \
+    ""
+
+  pushd "$BATS_TEST_TMPDIR/workspace" || return 1
+
+  run_dodder checkin :
+  assert_success
+
+  # Delete the CalDAV resource so checkout's PUT is a create rather than
+  # an update. PutTask with empty ETag uses If-None-Match: * (create
+  # semantics); ETag-based updates are tracked in #103 (haustoria
+  # caching).
+  curl -s -X DELETE \
+    -u "$CALDAV_USERNAME:$CALDAV_PASSWORD" \
+    "${CALDAV_URL}rt-multi.ics" >/dev/null 2>&1
+
+  # Checkout decompiles the blob's notes back into VTODO DESCRIPTION.
+  run_dodder checkout :z
+  assert_success
+
+  run get_vtodo_ical "$CALDAV_URL" "rt-multi"
+  assert_success
+  # iCalendar uses \n (literal backslash-n) for line breaks inside text
+  # values. The original three-line description should appear in the
+  # VTODO body with these escape sequences.
+  assert_output --partial 'DESCRIPTION:first line\nsecond line\nthird line'
+
+  popd || return 1
+}
+
+# Edge case: out-of-band VTODO PRIORITY value (not 0/1/5/9) buckets to
+# the nearest canonical field value. PRIORITY:3 should bucket to p1.
+function caldav_round_trip_out_of_band_priority { # @test
+  bootstrap_haustoria_workspace
+
+  put_vtodo_full \
+    "$CALDAV_URL" \
+    "rt-prio-3" \
+    "Off-band priority" \
+    "NEEDS-ACTION" \
+    "3" \
+    "" \
+    "" \
+    ""
+
+  pushd "$BATS_TEST_TMPDIR/workspace" || return 1
+
+  run_dodder checkin :
+  assert_success
+
+  run_dodder show '!task'
+  assert_success
+  assert_output --partial 'priority=p1'
 
   popd || return 1
 }


### PR DESCRIPTION
Plan-only PR. Comment on `docs/plans/2026-04-06-task-type-genesis-and-haustoria-fields.md` directly to drive decisions.

Drops the `!vtodo` persisted-type plan (`docs/plans/2026-04-05-vtodo-langlang-design.md`) — VTODO format becomes a haustoria-side concern only. Two changes proposed:

1. Formally commit `!task` into the bigbang/genesis process with `status` / `priority` / `due` field definitions, alongside the existing `!md` default type.
2. Hardcode VTODO ↔ `!task` field mapping inside `mike/haustoria_caldav` (compile + decompile), replacing the lossy `status-tags` config.

Six decisions to confirm in the "Decisions to confirm" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)