### PR TITLE
WIP: init-workspace pointer-store wiring (closes #200 once tests pass)

### DIFF
--- a/go/internal/foxtrot/env_repo/big_bang.go
+++ b/go/internal/foxtrot/env_repo/big_bang.go
@@ -24,6 +24,13 @@ type BigBang struct {
 	IncludeDefaultPandocTools     bool
 	IncludeBuiltinActionableTypes bool
 	BlobStoreId                   blob_store_id.Id
+
+	// BlobStoreConfigInit, when non-nil AND BlobStoreId is non-empty,
+	// causes Genesis to write this config to disk at the BlobStoreId's
+	// blob_store-config path before blob-store discovery. Used by
+	// init-workspace to install a TomlPointerV1 pointing at the parent
+	// repo's blob store.
+	BlobStoreConfigInit *blob_store_configs.TypedMutableConfig
 }
 
 func (bigBang *BigBang) SetDefaults() {

--- a/go/internal/foxtrot/env_repo/genesis.go
+++ b/go/internal/foxtrot/env_repo/genesis.go
@@ -74,6 +74,7 @@ func (env *Env) Genesis(bigBang BigBang) {
 	env.writeInventoryListLog()
 	env.writeConfig(bigBang)
 	env.writeBlobStoreConfigIfNecessary(bigBang, env.blobStoreEnv.BlobStore)
+	env.writeBlobStoreConfigInit(bigBang, env.blobStoreEnv.BlobStore)
 
 	// Re-make the blob_store_env now that the on-disk config exists,
 	// so store discovery picks up the freshly-written config. Reuses
@@ -163,6 +164,47 @@ func (env *Env) writeBlobStoreConfigIfNecessary(
 		&blob_store_configs.TypedConfig{
 			Type: blobStoreConfig.Type,
 			Blob: blobStoreConfig.Blob,
+		},
+		blobStoreConfigPath,
+	); err != nil {
+		env.Cancel(err)
+		return
+	}
+}
+
+// writeBlobStoreConfigInit writes bigBang.BlobStoreConfigInit to disk at
+// bigBang.BlobStoreId's blob_store-config path. Used by init-workspace
+// to install a pointer-store config under .<workspace-name>/ before
+// blob-store discovery re-runs. Skipped when either field is unset.
+func (env *Env) writeBlobStoreConfigInit(
+	bigBang BigBang,
+	directoryLayout mad_directory_layout.BlobStore,
+) {
+	if bigBang.BlobStoreConfigInit == nil {
+		return
+	}
+
+	if bigBang.BlobStoreId.IsEmpty() {
+		return
+	}
+
+	blobStorePath := mad_directory_layout.GetBlobStorePath(
+		directoryLayout,
+		bigBang.BlobStoreId.String(),
+	)
+	blobStoreConfigPath := blobStorePath.GetConfig()
+	blobStoreConfigDir := filepath.Dir(blobStoreConfigPath)
+
+	if err := env.MakeDirs(blobStoreConfigDir); err != nil {
+		env.Cancel(err)
+		return
+	}
+
+	if err := hyphence.EncodeToFile(
+		blob_store_configs.Coder,
+		&blob_store_configs.TypedConfig{
+			Type: bigBang.BlobStoreConfigInit.Type,
+			Blob: bigBang.BlobStoreConfigInit.Blob,
 		},
 		blobStoreConfigPath,
 	); err != nil {

--- a/go/internal/uniform/commands_dodder/init_workspace.go
+++ b/go/internal/uniform/commands_dodder/init_workspace.go
@@ -10,6 +10,7 @@ import (
 	"code.linenisgreat.com/dodder/go/internal/bravo/env_dir"
 	"code.linenisgreat.com/dodder/go/internal/bravo/env_ui"
 	"code.linenisgreat.com/dodder/go/internal/bravo/ids"
+	"github.com/amarbel-llc/madder/go/pkgs/blob_store_configs"
 	env_local "github.com/amarbel-llc/madder/go/pkgs/env_local"
 	"code.linenisgreat.com/dodder/go/internal/charlie/repo_config_cli"
 	"code.linenisgreat.com/dodder/go/internal/delta/command"
@@ -242,7 +243,15 @@ func (cmd InitWorkspace) runExperimentalRepo(req command.Request) {
 	cmd.Genesis.BigBang.ExcludeDefaultType = true
 	cmd.linkParentZettelIdProviders(absParentPath, parentIsHomeRepo)
 
-	local := cmd.OnTheFirstDay(req, req.PopArg("workspace repo id"))
+	workspaceRepoIdString := req.PopArg("workspace repo id")
+	cmd.setupParentPointerBlobStore(
+		req,
+		workspaceRepoIdString,
+		absParentPath,
+		parentIsHomeRepo,
+	)
+
+	local := cmd.OnTheFirstDay(req, workspaceRepoIdString)
 
 	remote := cmd.makeParentRemote(req, local, absParentPath, parentIsHomeRepo)
 
@@ -317,6 +326,76 @@ func (cmd InitWorkspace) runExperimentalRepo(req command.Request) {
 	); err != nil {
 		req.Cancel(err)
 	}
+}
+
+// setupParentPointerBlobStore configures the workspace's blob store to be
+// a TomlPointerV1 that resolves to the parent repo's default blob store.
+// Sets BigBang.BlobStoreId to ".<workspace-name>" so writeBlobStoreConfigIfNecessary
+// skips writing a fresh local-hash-bucketed default, and so the konfig's
+// blob-stores list (populated from BlobStoreId at local_working_copy/genesis.go)
+// names the pointer. Sets BigBang.BlobStoreConfigInit so env_repo.Genesis
+// writes the pointer config at the workspace's <pointer-id>/blob_store-config
+// path before madder re-discovers blob stores.
+func (cmd *InitWorkspace) setupParentPointerBlobStore(
+	req command.Request,
+	workspaceRepoIdString, absParentPath string,
+	parentIsHomeRepo bool,
+) {
+	parentBlobStoreBasePath := cmd.parentBlobStoreBasePath(
+		absParentPath,
+		parentIsHomeRepo,
+	)
+
+	if !files.Exists(parentBlobStoreBasePath) {
+		req.Cancel(
+			errors.BadRequestf(
+				"parent repo has no default blob store at %s",
+				parentBlobStoreBasePath,
+			),
+		)
+		return
+	}
+
+	pointerIdString := "." + workspaceRepoIdString
+	if err := cmd.Genesis.BigBang.BlobStoreId.Set(pointerIdString); err != nil {
+		req.Cancel(err)
+		return
+	}
+
+	pointerConfig := &blob_store_configs.TomlPointerV1{
+		BasePath: parentBlobStoreBasePath,
+	}
+
+	cmd.Genesis.BigBang.BlobStoreConfigInit = &blob_store_configs.TypedMutableConfig{
+		Type: blob_store_configs.TypeStructForConfig(pointerConfig),
+		Blob: pointerConfig,
+	}
+}
+
+// parentBlobStoreBasePath returns the absolute filesystem path of the
+// parent repo's default blob store directory. The home-repo case uses
+// the user-XDG madder data layout; the -parent case uses the parent's
+// CWD-scoped .madder/ tree.
+func (cmd InitWorkspace) parentBlobStoreBasePath(
+	absParentPath string,
+	parentIsHomeRepo bool,
+) string {
+	if parentIsHomeRepo {
+		home, _ := os.UserHomeDir()
+		return filepath.Join(
+			home,
+			"."+command_components_dodder.XDGUtilityNameMadder,
+			"local", "share",
+			"blob_stores", "default",
+		)
+	}
+
+	return filepath.Join(
+		absParentPath,
+		"."+command_components_dodder.XDGUtilityNameMadder,
+		"local", "share",
+		"blob_stores", "default",
+	)
 }
 
 func (cmd InitWorkspace) resolveParentPath(

--- a/zz-tests_bats/justfile
+++ b/zz-tests_bats/justfile
@@ -1,9 +1,7 @@
-bin_dir := env("BATS_BIN_DIR", "")
 # Exclude af_unix, haustoria, sftp, and serve-tagged files; they need
 # special sandbox options (local network binding / unix sockets) and
 # run via test-bats-network instead.
 _sandboxed_bats := `grep -L -e 'file_tags=.*af_unix' -e 'file_tags=.*haustoria' -e 'file_tags=.*sftp' -e 'file_tags=.*serve' current_version/*.bats | tr '\n' ' '`
-_bin_dir_arg := if bin_dir != "" { "--bin-dir " + bin_dir } else { "" }
 
 export DODDER_XDG_UTILITY_OVERRIDE := ""
 
@@ -67,19 +65,19 @@ bats_timeout := "30"
 [group("test")]
 test-targets *targets="current_version/*.bats":
   BATS_TEST_TIMEOUT="{{bats_timeout}}" \
-    bats {{_bin_dir_arg}} --jobs {{num_cpus()}} {{targets}}
+    bats --jobs {{num_cpus()}} {{targets}}
 
 # runs specific bats test tags
 [group("test")]
 test-tags *tags:
   BATS_TEST_TIMEOUT="{{bats_timeout}}" \
-    bats {{_bin_dir_arg}} --jobs {{num_cpus()}} --filter-tags {{tags}} current_version/*.bats
+    bats --jobs {{num_cpus()}} --filter-tags {{tags}} current_version/*.bats
 
 # runs specific bats test tags without sandbox
 [group("test")]
 test-tags-no-sandbox *tags:
   BATS_TEST_TIMEOUT="{{bats_timeout}}" \
-    bats {{_bin_dir_arg}} --no-sandbox --jobs {{num_cpus()}} --filter-tags {{tags}} current_version/*.bats
+    bats --no-sandbox --jobs {{num_cpus()}} --filter-tags {{tags}} current_version/*.bats
 
 [group("test")]
 test-integration: (test-targets "current_version/*.bats")


### PR DESCRIPTION
## Status

**WIP / Draft.** Pointer-store wiring compiles. Standalone bats runs pass. Full test-bats (nix-lane) fails 3 tests with a nil-pointer panic.

A fresh session should be able to pick up by reading this PR + #200 + the commit messages.

## What's done

Commit `b289b4152` — **bats infra fix.** Drops `--bin-dir` flag from `zz-tests_bats/justfile`. The flag was removed in upstream `amarbel-llc/bats`; on PATH is the new bats, which rejected the flag. Tests now run. Follow-up issue #204 tracks dropping the broader `BATS_BIN_DIR` plumbing.

Commit `e280e674d` — **pointer-store wiring (WIP).** Implements the design in #200:

- `BigBang.BlobStoreConfigInit *blob_store_configs.TypedMutableConfig` (new field). When non-nil with non-empty `BlobStoreId`, `env_repo.Genesis` writes this config at the BlobStoreId's blob_store-config path before madder's blob-store rediscovery.
- `init_workspace.runExperimentalRepo`:
  - Pops `workspace repo id` arg earlier.
  - Computes parent's default blob store base path (`<parent>/.madder/local/share/blob_stores/default` for `-parent`, or `~/.madder/local/share/blob_stores/default` for home repo).
  - Validates the path exists.
  - Sets `BigBang.BlobStoreId = .<workspace-name>` (so the konfig's `blob-stores = [".<workspace-name>"]` per the existing logic at `local_working_copy/genesis.go:74-78`, AND so `writeBlobStoreConfigIfNecessary` skips writing a fresh `default`).
  - Sets `BigBang.BlobStoreConfigInit` to a `TomlPointerV1{BasePath: <parent-abs-path>}` wrapped in `TypedMutableConfig`.

Result: workspace's `.madder/local/share/blob_stores/.<workspace-name>/blob_store-config` is a pointer to the parent's blob store. Workspace reads/writes flow through to the parent's storage.

## What's broken

The nix-lane `test-bats` run fails 3 tests with the same panic:

```
runtime error: invalid memory address or nil pointer dereference
├── # (*BlobStoreInitialized).GetDefaultHashType
│   <autogenerated>:1
├── # Factory.getBlobDigestType
│   .../internal/echo/object_metadata_fmt_hyphence/factory.go:47
├── # Factory.MakeTextParser
│   .../internal/echo/object_metadata_fmt_hyphence/factory.go:40
├── # Make
│   .../internal/lima/store_fs/main.go:58
├── # Make
│   .../internal/mike/env_workspace/main.go:142
├── # (*Repo).initialize
│   .../internal/romeo/local_working_copy/main.go:155
```

Failing tests:
- `check_workspace_dirty_after_local_change` (test 58 in full suite)
- `check_workspace_dirty_clean_after_push` (test 59)
- `workspace_repo_init_bare_query_excludes_unrelated` (test 464)

All three: init-workspace -parent ... succeeds, then a follow-up `dodder new` or `dodder show` in the workspace panics. The same tests pass standalone (`just test-bats-targets <file>`).

## Diagnosis so far

The panic means madder's `GetDefaultBlobStore()` returned a `BlobStoreInitialized{}` with a nil embedded `BlobStore` interface. That happens when the pointer-config resolver (`madder/internal/foxtrot/blob_stores/main.go:402` `case blob_store_configs.ConfigPointer:`) calls `hyphence.DecodeFromFile(blob_store_configs.Coder, otherStorePath.GetConfig())` and it fails — but `ctx.Cancel(err)` doesn't actually stop the broader code path from dereferencing the half-initialized store.

The pointer's `BasePath` was computed from `absParentPath` (already absolute) joined with `.madder/local/share/blob_stores/default`. In the nix sandbox this path may not be readable when the second dodder process runs.

## Suggested next steps for the picking-up session

1. **Get visibility into the pointer's runtime `BasePath`**: temporarily print it inside `setupParentPointerBlobStore` and `MakeBlobStore` → re-run the failing lane test → see what path is actually being dereferenced.
2. **Or use `--no-tempdir-cleanup`** on a failing standalone repro (if you can construct one) to inspect the workspace's `.madder/.../.<workspace-name>/blob_store-config` post-mortem.
3. **Possibly upstream-madder bug**: the resolver's `ctx.Cancel(err)` doesn't actually halt initialization. Could be worth a separate madder issue.
4. **Home-repo path resolution** (`parentBlobStoreBasePath` when `parentIsHomeRepo`): I hardcoded `~/.madder/...` matching what worked locally, but this may not match what `env_dir.MakeDefaultAndInitialize` actually resolves under a custom `XDG_DATA_HOME` (bats sandbox sets `XDG_DATA_HOME=$BATS_TEST_TMPDIR/.xdg/data` but blob stores still land at `<sandbox>/.madder/...` — verify this is robust or refactor to construct a parent env_dir).

## References

- Plan: `~/.claude/plans/streamed-herding-glade.md` (local)
- Dodder issue: #200
- Madder pre-req (closed): amarbel-llc/madder#186
- Flake bump: commit `841dd635f`
- Follow-up cleanup: #204

🤡 Generated with [Clown](https://github.com/amarbel-llc/clown)