### PR TITLE
Add fixed-size stream index implementation with config support

### DIFF
--- a/go/internal/charlie/repo_config_cli/main.go
+++ b/go/internal/charlie/repo_config_cli/main.go
@@ -22,6 +22,7 @@ type Config struct {
 
 	CheckoutCacheEnabled bool
 	PredictableZettelIds bool
+	StreamIndexFixed     bool
 
 	printOptionsOverlay options_print.Overlay
 	ToolOptions         options_tools.Options
@@ -63,6 +64,13 @@ func (config *Config) SetFlagDefinitions(flagSet interfaces.CLIFlagDefinitions) 
 		"generate new zettel ids in order",
 	)
 
+	flagSet.BoolVar(
+		&config.StreamIndexFixed,
+		"stream-index-fixed",
+		false,
+		"use the fixed-size-row-with-overflow stream index instead of the variable-length index",
+	)
+
 	config.printOptionsOverlay.AddToFlags(flagSet)
 	config.ToolOptions.SetFlagDefinitions(flagSet)
 
@@ -100,6 +108,10 @@ func Default() (config *Config) {
 
 func (config Config) UsePredictableZettelIds() bool {
 	return config.PredictableZettelIds
+}
+
+func (config Config) UseStreamIndexFixed() bool {
+	return config.StreamIndexFixed
 }
 
 func (config Config) GetConfigCLI() config_cli.Config {

--- a/go/internal/charlie/repo_configs/v2.go
+++ b/go/internal/charlie/repo_configs/v2.go
@@ -10,11 +10,12 @@ import (
 
 //go:generate tommy generate
 type V2 struct {
-	BlobStores     []blob_store_id.Id     `toml:"blob-stores"`
-	Defaults       DefaultsV1             `toml:"defaults"`
-	FileExtensions file_extensions.TOMLV1 `toml:"file-extensions"`
-	PrintOptions   options_print.V2       `toml:"cli-output"`
-	Tools          options_tools.Options  `toml:"tools"`
+	BlobStores       []blob_store_id.Id     `toml:"blob-stores"`
+	Defaults         DefaultsV1             `toml:"defaults"`
+	FileExtensions   file_extensions.TOMLV1 `toml:"file-extensions"`
+	PrintOptions     options_print.V2       `toml:"cli-output"`
+	Tools            options_tools.Options  `toml:"tools"`
+	StreamIndexFixed bool                   `toml:"stream-index-fixed,omitempty"`
 }
 
 func (config *V2) Reset() {
@@ -23,6 +24,7 @@ func (config *V2) Reset() {
 	config.Defaults.Type = ids.TypeStruct{}
 	config.Defaults.Tags = make([]ids.TagStruct, 0)
 	config.PrintOptions = options_print.V2{}
+	config.StreamIndexFixed = false
 }
 
 func (config *V2) ResetWith(b *V2) {
@@ -37,6 +39,8 @@ func (config *V2) ResetWith(b *V2) {
 	copy(config.Defaults.Tags, b.Defaults.Tags)
 
 	config.PrintOptions = b.PrintOptions
+
+	config.StreamIndexFixed = b.StreamIndexFixed
 }
 
 func (config V2) GetDefaults() Defaults {
@@ -57,4 +61,8 @@ func (config V2) GetToolOptions() options_tools.Options {
 
 func (config V2) GetBlobStores() []blob_store_id.Id {
 	return config.BlobStores
+}
+
+func (config V2) GetStreamIndexFixed() bool {
+	return config.StreamIndexFixed
 }

--- a/go/internal/charlie/repo_configs/v2_tommy.go
+++ b/go/internal/charlie/repo_configs/v2_tommy.go
@@ -53,6 +53,11 @@ func DecodeV2(input []byte) (*V2Document, error) {
 				}
 				d.consumed["blob-stores"] = true
 			}
+		case "stream-index-fixed":
+			if v, ok := cst.ExtractBool(_kv); ok {
+				d.data.StreamIndexFixed = v
+				d.consumed["stream-index-fixed"] = true
+			}
 		}
 	}
 	for _, _ch := range d.cstDoc.Root().Children {
@@ -130,6 +135,13 @@ func (d *V2Document) Encode() ([]byte, error) {
 		if err := cst.SetAny(d.cstDoc.Root(), "blob-stores", vals); err != nil {
 			return nil, fmt.Errorf("%w", err)
 		}
+	}
+	if d.data.StreamIndexFixed != false {
+		if err := cst.SetAny(d.cstDoc.Root(), "stream-index-fixed", d.data.StreamIndexFixed); err != nil {
+			return nil, fmt.Errorf("%w", err)
+		}
+	} else {
+		cst.DeleteValue(d.cstDoc.Root(), "stream-index-fixed")
 	}
 	{
 		tableNode := cst.EnsureChildTable(d.cstDoc.Root(), d.cstDoc.Root(), "defaults")
@@ -211,6 +223,11 @@ func DecodeV2Into(data *V2, doc *document.Document, container *cst.Node, consume
 				}
 				consumed[keyPrefix+"blob-stores"] = true
 			}
+		case "stream-index-fixed":
+			if v, ok := cst.ExtractBool(_kv); ok {
+				data.StreamIndexFixed = v
+				consumed[keyPrefix+"stream-index-fixed"] = true
+			}
 		}
 	}
 	for _, _ch := range doc.Root().Children {
@@ -285,6 +302,13 @@ func EncodeV2From(data *V2, doc *document.Document, container *cst.Node) error {
 		if err := cst.SetAny(container, "blob-stores", vals); err != nil {
 			return fmt.Errorf("%w", err)
 		}
+	}
+	if data.StreamIndexFixed != false {
+		if err := cst.SetAny(container, "stream-index-fixed", data.StreamIndexFixed); err != nil {
+			return fmt.Errorf("%w", err)
+		}
+	} else {
+		cst.DeleteValue(container, "stream-index-fixed")
 	}
 	{
 		tableNode := cst.EnsureChildTable(doc.Root(), container, "defaults")

--- a/go/internal/delta/repo_configs/main.go
+++ b/go/internal/delta/repo_configs/main.go
@@ -46,6 +46,7 @@ type (
 	ConfigOverlay2 interface {
 		ConfigOverlay
 		GetBlobStores() []blob_store_id.Id
+		GetStreamIndexFixed() bool
 	}
 )
 
@@ -98,6 +99,17 @@ func GetBlobStores(
 ) []blob_store_id.Id {
 	if config, ok := config.(ConfigOverlay2); ok {
 		return config.GetBlobStores()
+	} else {
+		return otherwise
+	}
+}
+
+func GetStreamIndexFixed(
+	config ConfigOverlay,
+	otherwise bool,
+) bool {
+	if config, ok := config.(ConfigOverlay2); ok {
+		return config.GetStreamIndexFixed()
 	} else {
 		return otherwise
 	}

--- a/go/internal/foxtrot/sku/index.go
+++ b/go/internal/foxtrot/sku/index.go
@@ -5,6 +5,7 @@ import (
 	"code.linenisgreat.com/dodder/go/internal/bravo/ids"
 	mad_domain_interfaces "github.com/amarbel-llc/madder/go/pkgs/domain_interfaces"
 	"github.com/amarbel-llc/madder/go/pkgs/markl"
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/interfaces"
 )
 
 type (
@@ -72,6 +73,34 @@ type (
 	Reindexer interface {
 		IndexPrimitives
 		IndexMutation
+	}
+
+	// StreamIndex is the full behavioral contract of a concrete stream index
+	// implementation, allowing the store to remain agnostic about whether the
+	// variable-length or fixed-size-row-with-overflow index is in use.
+	StreamIndex interface {
+		IndexMutable
+
+		Reset() (err error)
+
+		Flush(
+			printerHeader interfaces.FuncIter[string],
+		) (err error)
+
+		ReadPrimitiveQuery(
+			queryGroup PrimitiveQueryGroup,
+			funcIter interfaces.FuncIter[*Transacted],
+		) (err error)
+
+		SetNeedsFlushHistory(changes []string)
+
+		VerifyObjectProbes(object *Transacted) (err error)
+
+		PrintAllProbes() (err error)
+
+		MakeReindexer(
+			ctx interfaces.ActiveContext,
+		) (reindexer Reindexer, err error)
 	}
 )
 

--- a/go/internal/hotel/stream_index/main.go
+++ b/go/internal/hotel/stream_index/main.go
@@ -46,6 +46,7 @@ type Index struct {
 var (
 	_ sku.Index        = &Index{}
 	_ sku.IndexMutable = &Index{}
+	_ sku.StreamIndex  = &Index{}
 )
 
 func MakeIndex(
@@ -105,15 +106,15 @@ func (index *Index) Reset() (err error) {
 
 func (index *Index) MakeReindexer(
 	ctx interfaces.ActiveContext,
-) (reindexer *Reindexer, err error) {
+) (reindexer sku.Reindexer, err error) {
 	if err = index.Initialize(); err != nil {
 		err = errors.Wrap(err)
 		return reindexer, err
 	}
 
-	reindexer = &Reindexer{index: index}
+	concrete := &Reindexer{index: index}
 
-	for n := range reindexer.pages {
+	for n := range concrete.pages {
 		fb := &pageAdditionsFileBacked{}
 
 		if err = fb.initialize(index); err != nil {
@@ -121,11 +122,13 @@ func (index *Index) MakeReindexer(
 			return reindexer, err
 		}
 
-		reindexer.pages[n] = fb
+		concrete.pages[n] = fb
 		index.pages[n].additionsLatest = fb
 
 		errors.ContextCloseAfter(ctx, fb)
 	}
+
+	reindexer = concrete
 
 	return reindexer, err
 }

--- a/go/internal/hotel/stream_index_fixed/main.go
+++ b/go/internal/hotel/stream_index_fixed/main.go
@@ -47,6 +47,7 @@ type Index struct {
 var (
 	_ sku.Index        = &Index{}
 	_ sku.IndexMutable = &Index{}
+	_ sku.StreamIndex  = &Index{}
 )
 
 func MakeIndex(

--- a/go/internal/hotel/stream_index_fixed/probes.go
+++ b/go/internal/hotel/stream_index_fixed/probes.go
@@ -187,6 +187,15 @@ func (index *Index) readOneLoc(
 	return
 }
 
+func (index *Index) PrintAllProbes() (err error) {
+	if index.probeIndex.index.PrintAll(index.envRepo); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	return err
+}
+
 func (index *Index) VerifyObjectProbes(
 	object *sku.Transacted,
 ) (err error) {

--- a/go/internal/hotel/stream_index_fixed/reindexer.go
+++ b/go/internal/hotel/stream_index_fixed/reindexer.go
@@ -1,0 +1,59 @@
+package stream_index_fixed
+
+import (
+	"code.linenisgreat.com/dodder/go/internal/bravo/ids"
+	"code.linenisgreat.com/dodder/go/internal/foxtrot/sku"
+	mad_domain_interfaces "github.com/amarbel-llc/madder/go/pkgs/domain_interfaces"
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/interfaces"
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/errors"
+)
+
+// Reindexer rebuilds the fixed-size index from scratch. Unlike the
+// variable-length index it does not swap in file-backed page additions; the
+// fixed index keeps its additions in memory and is flushed page-by-page, so
+// the reindexer simply delegates to the underlying index.
+type Reindexer struct {
+	index *Index
+}
+
+var _ sku.Reindexer = &Reindexer{}
+
+func (reindexer *Reindexer) Add(
+	object *sku.Transacted,
+	options sku.CommitOptions,
+) (err error) {
+	return reindexer.index.Add(object, options)
+}
+
+func (reindexer *Reindexer) ObjectExists(
+	objectId *ids.ObjectId,
+) (err error) {
+	return reindexer.index.ObjectExists(objectId)
+}
+
+func (reindexer *Reindexer) ReadOneMarklIdAdded(
+	marklId mad_domain_interfaces.MarklId,
+	object *sku.Transacted,
+) (ok bool) {
+	return reindexer.index.ReadOneMarklIdAdded(marklId, object)
+}
+
+func (reindexer *Reindexer) ReadOneMarklId(
+	marklId mad_domain_interfaces.MarklId,
+	object *sku.Transacted,
+) (ok bool) {
+	return reindexer.index.ReadOneMarklId(marklId, object)
+}
+
+func (index *Index) MakeReindexer(
+	ctx interfaces.ActiveContext,
+) (reindexer sku.Reindexer, err error) {
+	if err = index.Initialize(); err != nil {
+		err = errors.Wrap(err)
+		return reindexer, err
+	}
+
+	reindexer = &Reindexer{index: index}
+
+	return reindexer, err
+}

--- a/go/internal/november/store_config/compiled.go
+++ b/go/internal/november/store_config/compiled.go
@@ -66,6 +66,17 @@ func (config Config) GetBlobStores() []blob_store_id.Id {
 	return repo_configs.GetBlobStores(config.configRepo, nil)
 }
 
+// GetStreamIndexFixed resolves whether the fixed-size-row-with-overflow stream
+// index should be used. The persisted repo config overlay supplies the default;
+// the CLI flag (--stream-index-fixed) forces it on regardless of the overlay.
+func (config Config) GetStreamIndexFixed() bool {
+	if config.CLI.UseStreamIndexFixed() {
+		return true
+	}
+
+	return repo_configs.GetStreamIndexFixed(config.configRepo, false)
+}
+
 func (config Config) GetPrintOptions() options_print.Options {
 	return config.PrintOptions
 }

--- a/go/internal/oscar/store/accessors.go
+++ b/go/internal/oscar/store/accessors.go
@@ -5,7 +5,6 @@ import (
 	"code.linenisgreat.com/dodder/go/internal/foxtrot/env_repo"
 	"code.linenisgreat.com/dodder/go/internal/foxtrot/sku"
 	"code.linenisgreat.com/dodder/go/internal/foxtrot/zettel_id_index"
-	"code.linenisgreat.com/dodder/go/internal/hotel/stream_index"
 	"code.linenisgreat.com/dodder/go/internal/india/inventory_list_store"
 	"code.linenisgreat.com/dodder/go/internal/india/typed_blob_store"
 	"code.linenisgreat.com/dodder/go/internal/november/store_config"
@@ -52,6 +51,6 @@ func (store *Store) GetConfigStoreMutable() store_config.StoreMutable {
 	return store.storeConfig
 }
 
-func (store *Store) GetStreamIndex() *stream_index.Index {
+func (store *Store) GetStreamIndex() sku.StreamIndex {
 	return store.streamIndex
 }

--- a/go/internal/oscar/store/main.go
+++ b/go/internal/oscar/store/main.go
@@ -10,6 +10,7 @@ import (
 	"code.linenisgreat.com/dodder/go/internal/golf/object_finalizer"
 	"code.linenisgreat.com/dodder/go/internal/hotel/env_lua"
 	"code.linenisgreat.com/dodder/go/internal/hotel/stream_index"
+	"code.linenisgreat.com/dodder/go/internal/hotel/stream_index_fixed"
 	"code.linenisgreat.com/dodder/go/internal/india/inventory_list_store"
 	"code.linenisgreat.com/dodder/go/internal/india/typed_blob_store"
 	"code.linenisgreat.com/dodder/go/internal/juliett/queries"
@@ -33,7 +34,7 @@ type Store struct {
 	workingList *sku.WorkingList
 	envLua      env_lua.Env
 
-	streamIndex   *stream_index.Index
+	streamIndex   sku.StreamIndex
 	finalizer     object_finalizer.Finalizer
 	zettelIdIndex zettel_id_index.Index
 	dormantIndex  *dormant_index.Index
@@ -93,14 +94,27 @@ func (store *Store) Initialize(
 		return err
 	}
 
-	if store.streamIndex, err = stream_index.MakeIndex(
-		store.GetEnvRepo(),
-		store.applyDormantAndRealizeTags,
-		store.GetEnvRepo().DirIndexObjects(),
-		store.sunrise,
-	); err != nil {
-		err = errors.Wrap(err)
-		return err
+	if store.storeConfig.GetConfig().GetStreamIndexFixed() {
+		if store.streamIndex, err = stream_index_fixed.MakeIndex(
+			store.GetEnvRepo(),
+			store.applyDormantAndRealizeTags,
+			store.GetEnvRepo().DirIndexObjects(),
+			store.sunrise,
+			0,
+		); err != nil {
+			err = errors.Wrap(err)
+			return err
+		}
+	} else {
+		if store.streamIndex, err = stream_index.MakeIndex(
+			store.GetEnvRepo(),
+			store.applyDormantAndRealizeTags,
+			store.GetEnvRepo().DirIndexObjects(),
+			store.sunrise,
+		); err != nil {
+			err = errors.Wrap(err)
+			return err
+		}
 	}
 
 	store.finalizer = object_finalizer.Make()


### PR DESCRIPTION
## Summary

Introduces a new fixed-size-row-with-overflow stream index implementation as an alternative to the existing variable-length index. The fixed index keeps additions in memory and flushes page-by-page, offering different performance characteristics. A new configuration option allows users to opt into this implementation.

## Key Changes

- **New `stream_index_fixed` package**: Implements `Reindexer` type that delegates to the underlying fixed-size index, mirroring the variable-length index's reindexer pattern but without file-backed page swapping.

- **`StreamIndex` interface**: Added to `sku/index.go` to abstract the behavioral contract of stream index implementations, allowing the store to remain agnostic about which concrete implementation is in use. Both variable-length and fixed-size indexes now implement this interface.

- **Configuration support**: 
  - Added `StreamIndexFixed` boolean field to `V2` repo config struct with TOML serialization
  - Generated tommy codegen files (`v2_tommy.go`) for config encode/decode
  - Added `--stream-index-fixed` CLI flag in `repo_config_cli`
  - Added `GetStreamIndexFixed()` accessor methods throughout the config hierarchy

- **Store initialization**: Modified `oscar/store/main.go` to conditionally instantiate either the fixed-size or variable-length index based on the `StreamIndexFixed` config setting.

- **Type assertions**: Both `stream_index.Index` and `stream_index_fixed.Index` now declare conformance to the `StreamIndex` interface.

- **Return type updates**: `MakeReindexer()` methods now return `sku.Reindexer` interface type instead of concrete types, enabling polymorphic behavior.

- **Probe support**: Added `PrintAllProbes()` method to fixed-size index to support the full `StreamIndex` interface contract.

## Implementation Details

The fixed-size index reindexer is simpler than the variable-length variant—it doesn't need to swap in file-backed page additions since the fixed index manages additions in-memory. The `MakeReindexer` method simply wraps the index and delegates all operations to it, whereas the variable-length reindexer sets up file-backed storage for page additions during reindexing.

The configuration plumbing follows the existing pattern: CLI flags override persisted repo config, which defaults to false (variable-length index remains the default behavior).

https://claude.ai/code/session_01Gnd8hLt5YWgzT4TZ9wPHqU