### PR TITLE
Add JSON content negotiation for read-only HTTP API clients

### DIFF
--- a/go/internal/sierra/remote_http/server.go
+++ b/go/internal/sierra/remote_http/server.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io"
+	"iter"
 	"net"
 	"net/http"
 	"net/url"
@@ -25,6 +27,7 @@ import (
 	"code.linenisgreat.com/dodder/go/internal/charlie/genesis_configs"
 	"code.linenisgreat.com/dodder/go/internal/foxtrot/sku"
 	"code.linenisgreat.com/dodder/go/internal/golf/box_format"
+	"code.linenisgreat.com/dodder/go/internal/golf/sku_json_fmt"
 	"code.linenisgreat.com/dodder/go/internal/juliett/queries"
 	"code.linenisgreat.com/dodder/go/internal/papa/repo"
 	"code.linenisgreat.com/dodder/go/internal/romeo/local_working_copy"
@@ -54,6 +57,14 @@ type Server struct {
 	// an in-memory keypair so the sign/verify round trip can be
 	// exercised without standing up a real Repo on disk.
 	KeySource KeySource
+
+	// Public relaxes the signing middleware so read clients that
+	// cannot mint a challenge nonce (e.g. the dodder-backed website
+	// API, which talks plain HTTP) are served without server
+	// attestation. Requests that still carry a challenge nonce are
+	// signed exactly as before, so the sync client round trip is
+	// unaffected. Leave false in production sync deployments.
+	Public bool
 
 	blobCache serverBlobCache
 
@@ -346,8 +357,19 @@ func (server *Server) sigMiddleware(next http.Handler) http.Handler {
 				return
 			}
 
+			nonce := request.Header.Get(headerChallengeNonce)
+
+			// Public read mode: a client that omits the challenge
+			// nonce is served without server attestation. A nonce, if
+			// present, is still honored so sync clients keep getting a
+			// signed challenge response.
+			if nonce == "" && server.Public {
+				next.ServeHTTP(responseWriter, request)
+				return
+			}
+
 			if err := server.addSignatureIfNecessary(
-				request.Header.Get(headerChallengeNonce),
+				nonce,
 				responseWriter.Header(),
 			); err != nil {
 				http.Error(responseWriter, err.Error(), http.StatusBadRequest)
@@ -755,6 +777,73 @@ func (server *Server) copyBlob(
 	return copyResult, err
 }
 
+// acceptsJSON reports whether the request's Accept header opts into a
+// JSON representation. Used by the object/query handlers to negotiate
+// between the binary inventory-list wire format (the sync client) and
+// the JSON format consumed by the dodder-backed website API.
+func acceptsJSON(request Request) bool {
+	return strings.Contains(
+		request.Headers.Get("Accept"),
+		"application/json",
+	)
+}
+
+// wantsBlobString reports whether the JSON representation should embed
+// the object's blob content as a string. Controlled by the
+// `blob_string` query parameter; defaults to def when unset. Embedding
+// is opt-out for single-object reads (the detail page needs the body)
+// and opt-in for collections (avoid reading every blob in a listing).
+func wantsBlobString(request Request, def bool) bool {
+	switch request.request.URL.Query().Get("blob_string") {
+	case "":
+		return def
+	case "true", "1":
+		return true
+	default:
+		return false
+	}
+}
+
+// writeObjectsJSON encodes a sequence of objects as a JSON array of
+// sku_json_fmt.Transacted, reusing the same formatter the `show
+// -format json` command emits so the wire shape stays consistent.
+func (server *Server) writeObjectsJSON(
+	seq iter.Seq[*sku.Transacted],
+	includeBlob bool,
+	response *Response,
+) {
+	var blobStore mad_domain_interfaces.BlobStore
+
+	if includeBlob {
+		blobStore = server.Repo.GetBlobStore()
+	}
+
+	items := make([]sku_json_fmt.Transacted, 0)
+
+	for object := range seq {
+		var item sku_json_fmt.Transacted
+
+		if err := item.FromTransacted(object, blobStore); err != nil {
+			response.Error(err)
+			return
+		}
+
+		items = append(items, item)
+	}
+
+	buffer := bytes.NewBuffer(nil)
+
+	encoder := json.NewEncoder(buffer)
+
+	if err := encoder.Encode(items); err != nil {
+		response.Error(err)
+		return
+	}
+
+	response.Headers().Set("Content-Type", "application/json; charset=utf-8")
+	response.Body = ohio.NopCloser(buffer)
+}
+
 func (server *Server) handleGetQuery(request Request) (response Response) {
 	var listTypeString string
 
@@ -806,6 +895,15 @@ func (server *Server) handleGetQuery(request Request) (response Response) {
 			response.Error(err)
 			return response
 		}
+	}
+
+	if acceptsJSON(request) {
+		server.writeObjectsJSON(
+			list.All(),
+			wantsBlobString(request, false),
+			&response,
+		)
+		return response
 	}
 
 	// TODO make this more performant by returning a proper reader
@@ -874,6 +972,19 @@ func (server *Server) handleGetObject(request Request) (response Response) {
 		return response
 	}
 
+	seqOne := func(yield func(*sku.Transacted) bool) {
+		yield(fetched)
+	}
+
+	if acceptsJSON(request) {
+		server.writeObjectsJSON(
+			seqOne,
+			wantsBlobString(request, true),
+			&response,
+		)
+		return response
+	}
+
 	listTypeString := server.Repo.GetImmutableConfigPublic().GetInventoryListTypeId()
 
 	buffer := bytes.NewBuffer(nil)
@@ -882,10 +993,6 @@ func (server *Server) handleGetObject(request Request) (response Response) {
 	defer repoolBufferedWriter()
 
 	inventoryListCoderCloset := server.Repo.GetInventoryListCoderCloset()
-
-	seqOne := func(yield func(*sku.Transacted) bool) {
-		yield(fetched)
-	}
 
 	if _, err := inventoryListCoderCloset.WriteBlobToWriter(
 		server.Repo,

--- a/go/internal/sierra/remote_http/server_json_negotiation_test.go
+++ b/go/internal/sierra/remote_http/server_json_negotiation_test.go
@@ -1,0 +1,107 @@
+//go:build test
+
+package remote_http
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"code.linenisgreat.com/dodder/go/internal/golf/sku_json_fmt"
+	"code.linenisgreat.com/dodder/go/internal/romeo/local_working_copy"
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/ui"
+	"github.com/gorilla/mux"
+
+	// Side-effect: register format-purpose pairs (matches production
+	// binaries). Required because the testing Repo's keypair
+	// generation goes through madder's markl format registry.
+	_ "github.com/amarbel-llc/madder/go/pkgs/markl_registrations"
+)
+
+// TestHandleGetQueryAcceptsJSON pins the content-negotiation contract
+// the dodder-backed website API depends on: a query request carrying
+// `Accept: application/json` is answered with a JSON array of
+// sku_json_fmt.Transacted rather than the binary inventory-list wire
+// format. Asserted against a freshly-initialized (empty-of-zettels)
+// store, so the body is a well-formed empty array — proof the JSON
+// branch is wired without depending on seed data.
+func TestHandleGetQueryAcceptsJSON(t1 *testing.T) {
+	ui.RunTestContext(t1, testHandleGetQueryAcceptsJSON)
+}
+
+func testHandleGetQueryAcceptsJSON(t *ui.TestContext) {
+	repo := local_working_copy.MakeTesting(t, nil)
+
+	server := &Server{
+		EnvLocal: repo,
+		Repo:     repo,
+	}
+
+	t.AssertNoError(server.init())
+
+	router := mux.NewRouter().UseEncodedPath()
+	router.HandleFunc(
+		"/query/{list_type}/{query}",
+		server.makeHandler(server.handleGetQuery),
+	).Methods("GET")
+
+	// list_type is intentionally arbitrary: the JSON branch never
+	// touches the inventory-list codec, so an unconfigured type id
+	// must not break negotiation.
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/query/"+url.QueryEscape("inventory_list")+"/"+url.QueryEscape(":z"),
+		nil,
+	)
+	req.Header.Set("Accept", "application/json")
+
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf(
+			"expected 200, got %d (body: %s)",
+			rec.Code, rec.Body.String(),
+		)
+	}
+
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json; charset=utf-8" {
+		t.Fatalf("expected json content-type, got %q", ct)
+	}
+
+	var items []sku_json_fmt.Transacted
+
+	if err := json.Unmarshal(rec.Body.Bytes(), &items); err != nil {
+		t.Fatalf(
+			"response body is not a JSON array of objects: %s (body: %s)",
+			err, rec.Body.String(),
+		)
+	}
+}
+
+// TestAcceptsJSON exercises the Accept-header negotiation predicate in
+// isolation so its behavior can't drift silently.
+func TestAcceptsJSON(t *testing.T) {
+	cases := map[string]bool{
+		"application/json":            true,
+		"application/json; q=0.9":     true,
+		"text/html, application/json": true,
+		"text/html":                   false,
+		"":                            false,
+	}
+
+	for accept, want := range cases {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		if accept != "" {
+			req.Header.Set("Accept", accept)
+		}
+
+		request := Request{Headers: req.Header}
+
+		if got := acceptsJSON(request); got != want {
+			t.Errorf("acceptsJSON(%q) = %v, want %v", accept, got, want)
+		}
+	}
+}

--- a/go/internal/uniform/commands_dodder/serve.go
+++ b/go/internal/uniform/commands_dodder/serve.go
@@ -43,6 +43,11 @@ type Serve struct {
 
 	TailscaleTLS bool
 
+	// Public serves read requests without requiring a challenge nonce,
+	// so plain-HTTP read clients (e.g. the dodder-backed website API)
+	// can fetch objects and blobs. See remote_http.Server.Public.
+	Public bool
+
 	// Handshake enables the hashicorp/go-plugin-style handshake. When
 	// set, the server forces tcp + ephemeral port, prints a single
 	// pipe-delimited handshake line on stdout
@@ -85,6 +90,13 @@ func (cmd *Serve) SetFlagDefinitions(
 	)
 
 	flagSet.BoolVar(
+		&cmd.Public,
+		"public",
+		false,
+		"serve read requests without requiring a challenge nonce (for plain-HTTP read clients such as the dodder-backed website API)",
+	)
+
+	flagSet.BoolVar(
 		&cmd.Handshake,
 		"handshake",
 		false,
@@ -109,6 +121,7 @@ func (cmd Serve) Run(req command.Request) {
 	server := remote_http.Server{
 		EnvLocal: envLocal,
 		Repo:     repo,
+		Public:   cmd.Public,
 	}
 
 	if cmd.TailscaleTLS {


### PR DESCRIPTION
## Summary

Adds content negotiation to the remote HTTP server to support plain-HTTP read clients (like the dodder-backed website API) that cannot mint challenge nonces. Clients can now request JSON representations of objects and query results via the `Accept: application/json` header, while maintaining full backward compatibility with the binary inventory-list wire format used by the sync client.

## Key Changes

- **Public mode flag**: Added `Public` field to `remote_http.Server` and `serve` command to relax signing middleware. When enabled, requests without a challenge nonce are served without server attestation, while requests carrying a nonce are still signed normally.

- **Content negotiation helpers**:
  - `acceptsJSON()`: Checks if request's `Accept` header includes `application/json`
  - `wantsBlobString()`: Interprets `blob_string` query parameter to control whether blob content is embedded in JSON output (opt-out for single objects, opt-in for collections)
  - `writeObjectsJSON()`: Encodes object sequences as JSON arrays using `sku_json_fmt.Transacted`, reusing the same formatter as the `show -format json` command

- **Handler updates**: Modified `handleGetQuery()` and `handleGetObject()` to check for JSON acceptance and return appropriate format before falling back to binary wire format

- **Imports**: Added `encoding/json`, `iter`, and `sku_json_fmt` package imports

- **Tests**: Added `server_json_negotiation_test.go` with:
  - `TestHandleGetQueryAcceptsJSON`: Verifies query requests with `Accept: application/json` return valid JSON arrays
  - `TestAcceptsJSON`: Unit tests the Accept header negotiation logic in isolation

## Implementation Details

The JSON branch is wired to never touch the inventory-list codec, allowing it to work with unconfigured type IDs. The `seqOne` helper in `handleGetObject()` was moved earlier to support both binary and JSON code paths. The signing middleware now extracts the challenge nonce once and uses it to decide whether to skip attestation entirely (public mode) or proceed with signing as before.

https://claude.ai/code/session_01UhwpUFsEz6KsxfS4swdc99