### PR TITLE
Add drtp websocket remote transfer protocol (hard fork of remote_http)

### DIFF
--- a/docs/rfcs/0004-remote-transfer-protocol.md
+++ b/docs/rfcs/0004-remote-transfer-protocol.md
@@ -206,6 +206,7 @@ Sent by each peer as its first frame. Body (TOML):
     websocket          = true                # transport actually in use is ws
     inventory-list-type = "inventory_list-v2"
     hash-format        = "blake2b256"
+    compression        = "zstd"              # blob compression supported ("" = none)
     expand-edges       = true                # sender computes closure
     public-key         = "..."               # markl id, for attestation
     nonce              = "..."               # challenge nonce (see Authentication)
@@ -315,8 +316,16 @@ length --- the terminator delimits the blob --- so a blob of any size moves with
 constant memory on both sides. A receiver writes each chunk to the blob store
 as it arrives, computes the content digest incrementally, and verifies it
 against the header `id` after the terminator; a mismatch aborts the transfer.
-Compression, if advertised in capabilities, is applied to the chunk payloads
-and MUST be reflected in a `compression` field on the header.
+
+Compression is negotiated, not assumed: each peer advertises a `compression`
+algorithm in its capabilities (`zstd`, or empty for none). The sender uses an
+algorithm only when the receiving peer also advertised it, and names it in the
+blob header's `compression` field; the receiver decompresses each blob's chunk
+stream before writing it. Because the digest is computed over the
+*decompressed* bytes, compression is transparent to content addressing --- the
+same blob produces the same markl ID whether or not it travelled compressed. A
+peer that does not understand the named algorithm MUST abort rather than store
+corrupt bytes.
 
 ### Versioning and Evolution
 

--- a/docs/rfcs/0004-remote-transfer-protocol.md
+++ b/docs/rfcs/0004-remote-transfer-protocol.md
@@ -178,8 +178,11 @@ horizontal versioning prescribes. The defined types are:
 - `drtp-capabilities-v1` --- capability advertisement (both directions).
 - `drtp-want-v1` --- the requested query plus transfer options (client to
   server for fetch; server to client for push).
-- `drtp-have-v1` --- object identities (with version digests) the receiver
-  already holds.
+- `drtp-manifest-v1` --- the sender's list of every blob digest in the closure
+  it holds, sent before the blob stream so the receiver can declare what it
+  already has.
+- `drtp-have-v1` --- the receiver's reply to the manifest: the subset of those
+  blob digests it already holds (and so the sender SHOULD NOT stream).
 - `drtp-blob_header-v1` --- announces the BLOB frame that follows.
 - `drtp-ack-v1` --- a phase acknowledgement (e.g. "objects received, here are
   the blobs I still need" or "transfer complete").
@@ -258,11 +261,13 @@ exchange is:
     computes a self-consistent graph so the receiver never imports an object
     whose type, tags, or referenced blobs are absent.
 
-4.  **Have (optional).** If the client advertised `have`, it sends one or more
-    `drtp-have-v1` frames enumerating the object identities and version digests
-    it already holds. The server omits those objects from the object stream and
-    omits blobs the client already has. Absent any `have`, the server sends the
-    whole closure (the clone case).
+4.  **Have-negotiation.** The server sends `drtp-manifest-v1` listing every
+    blob digest in the closure it holds. The client replies `drtp-have-v1` with
+    the subset it already has. The server then streams only the blobs the
+    client lacks. For a clone the client has nothing, so the whole closure
+    streams; for a re-pull into a populated repo only the new blobs move. (v1
+    negotiates blobs, the bandwidth cost; objects are small and always streamed,
+    relying on the importer's idempotent commit.)
 
 5.  **Objects.** The server sends the closure's objects as one or more CONTROL
     frames of the `inventory_list` type. The client imports them through the

--- a/docs/rfcs/0004-remote-transfer-protocol.md
+++ b/docs/rfcs/0004-remote-transfer-protocol.md
@@ -1,0 +1,406 @@
+---
+date: 2026-06-07
+status: proposed
+---
+
+# Remote Transfer Protocol
+
+## Abstract
+
+Dodder synchronizes objects and blobs between repositories over a remote
+transfer protocol. Today that protocol is *implicit*: it is whatever the
+`sierra/remote_http` client and server happen to send each other --- a sequence
+of REST calls (`GET /query`, `POST /inventory_lists`, `POST /blobs`) glued
+together by a reactive missing-blob retry loop. There is no document that
+specifies the exchange, no version negotiation, and no single connection over
+which a whole transfer happens; every request re-establishes framing and
+re-runs the signing handshake.
+
+This document specifies an explicit, versioned **remote transfer protocol**
+(`drtp`). It is a session protocol: one connection carries a complete transfer
+from capability handshake through object and blob streaming. It takes its
+overall shape from git's fetch/push (`send-pack` / `receive-pack` /
+`upload-pack`): capability advertisement, a `want`/`have` reference
+negotiation, and a single batched object stream. Unlike git, every control and
+payload message on the wire is a **typed hyphence document** (RFC 0001), so the
+protocol inherits hyphence's free versioning (type-string dispatch) and
+content-addressed, signable framing (RFC 0002 markl IDs) rather than inventing a
+bespoke pack format. The sender computes the transfer's transitive closure up
+front using the type system's *expand-edges* traversal, so a fetch delivers a
+complete, self-consistent object graph in one pass instead of discovering
+missing blobs by trial and error.
+
+The protocol MAY run over any reliable, ordered, bidirectional byte stream:
+stdio pipes (`dodder serve -`), a Unix domain socket, a raw TCP connection, or
+--- the motivating addition of this document --- a **WebSocket** upgraded from an
+ordinary HTTP request. WebSocket support is optional and negotiated: a client
+attempts the upgrade and falls back to the request/response transport when the
+peer does not offer it.
+
+The implementation is a hard fork of `sierra/remote_http` into a new package,
+`sierra/remote_proto`; the existing HTTP backend is retained unchanged for
+backward compatibility.
+
+## Introduction
+
+The HTTP backend grew organically and works, but its protocol is hard to reason
+about and hard to evolve:
+
+- **It is reactive about blobs.** `POST /inventory_lists` imports the objects a
+  client offers, replies with the subset of blobs it is *missing*, the client
+  uploads those, and the loop repeats until the server reports completion (the
+  `201`/`417` dance in `client.pullQueryGroupFromWorkingCopy`). Each round trip
+  is a full HTTP request. The local-to-local path
+  (`local_working_copy.pullQueryGroupFromWorkingCopy`) already does better: it
+  computes the *entire* set of reachable objects and blobs once, with
+  `expandEdges`, and copies them. The remote path does not use expand-edges at
+  all.
+
+- **It has no version negotiation.** There is a literal `// TODO local / remote
+  version negotiation` in the client. Two peers cannot discover each other's
+  protocol version, supported compression, or feature set; they can only hope
+  the REST surface matches.
+
+- **It re-handshakes per request.** The signing middleware
+  (`RoundTripperBufioWrappedSigner`) mints a nonce, verifies a challenge
+  response, and verifies a body-digest trailer on *every* request. Over a
+  high-latency link a transfer is dozens of serial handshakes.
+
+- **The framing is HTTP-specific.** The wire format is "whatever
+  `http.Request.Write` / `http.ReadResponse` produce," which couples the
+  protocol to Go's `net/http` and rules out transports (like WebSocket) that do
+  not present a fresh request per exchange.
+
+The goal is a protocol that is specified, versioned, computes its transfer up
+front via the type system, handshakes once per session, and is framed
+independently of any one transport so it can ride a WebSocket.
+
+### Relationship to existing work
+
+This protocol reuses, rather than replaces, three existing facilities:
+
+- **Hyphence (RFC 0001)** is the wire representation for every message. Control
+  messages are small typed blobs; object batches are exactly the
+  `inventory_list` hyphence stream the store already encodes
+  (`inventory_list_coders.Closet`).
+- **Markl IDs (RFC 0002)** address blobs, lock types, and carry signatures, so
+  the protocol's integrity and authentication reduce to existing markl
+  operations.
+- **Expand-edges** (`sku.EdgeExplorer`, `store.MakeEdgeExplorer`) computes the
+  transitive closure of an object set: its type object, every tag object,
+  referenced objects, blob references, and --- recursively, driven by each
+  type's `[references]` script --- nested blob and object references.
+
+## Requirements Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in RFC 2119.
+
+## Specification
+
+### Transport and Session
+
+A *session* is a single transfer conducted over one reliable, ordered,
+bidirectional byte stream (an `io.ReadWriteCloser`). The protocol is defined
+entirely in terms of that stream and is therefore transport-agnostic. A
+conforming implementation MUST support running a session over:
+
+1.  **stdio** --- the child process spawned by `dodder serve -`, whose stdin and
+    stdout are the stream (local and SSH transports);
+2.  **Unix domain socket** --- a `net.Conn` to a bound socket;
+3.  **TCP** --- a `net.Conn` to a `host:port`;
+4.  **WebSocket** --- a connection upgraded from HTTP, adapted to a `net.Conn`.
+
+The client opens the session; the server accepts it. Exactly one transfer
+(fetch or push) runs per session. After the transfer terminates, either peer
+MAY close the stream.
+
+#### WebSocket upgrade
+
+A server that supports WebSocket transport MUST expose an HTTP endpoint at the
+path `/drtp` that accepts the standard WebSocket upgrade (`GET` with
+`Upgrade: websocket`). On a successful upgrade the connection is adapted to a
+binary message stream: every protocol frame (below) is sent as one binary
+WebSocket message. The upgraded connection is then treated as the session's
+byte stream.
+
+A client requesting WebSocket transport MUST issue the upgrade to `/drtp`. If
+the upgrade fails --- because the peer is an older server that does not offer
+`/drtp`, or a proxy strips the upgrade --- the client MUST either fall back to a
+non-upgraded transport (the request/response HTTP backend, `remote_http`) or
+fail with a diagnostic that names the missing capability. This is the "optional
+upgrade": WebSocket is used when both peers support it and is never required.
+
+The `/healthz` liveness route and, for bootstrap, `/config-immutable` MAY be
+served alongside `/drtp` so that probes and capability discovery do not require
+an upgrade.
+
+### Framing
+
+The session byte stream carries a sequence of **frames**. A frame is:
+
+    +--------+-----------------+==================+
+    | kind   | length (uint32) | payload (length) |
+    +--------+-----------------+==================+
+
+- `kind` is a single byte identifying the payload's interpretation.
+- `length` is a big-endian unsigned 32-bit byte count of the payload.
+- `payload` is exactly `length` bytes.
+
+Two frame kinds are defined:
+
+- `kind = 0x01` **CONTROL**: the payload is a single typed hyphence document
+  (RFC 0001) whose type string is one of the control types below.
+- `kind = 0x02` **BLOB**: the payload is the raw bytes of one content-addressed
+  blob. A BLOB frame MUST be immediately preceded by a CONTROL frame of type
+  `drtp-blob_header-v1` naming the blob's markl ID and byte length.
+
+A receiver MUST reject a frame whose `length` exceeds a configured maximum
+(RECOMMENDED default 64 MiB for CONTROL frames; BLOB frames are bounded by the
+`drtp-blob_header-v1` length and MAY stream in chunks --- see Blob Streaming).
+Framing over WebSocket maps one frame to one binary message; framing over a raw
+byte stream writes the header and payload contiguously.
+
+The choice of length-prefixed frames (rather than hyphence's own `---`
+boundaries as the outer container) keeps the reader from having to scan for
+boundaries on an unbounded stream and lets BLOB payloads --- which are arbitrary
+bytes and need not be valid hyphence --- share one channel with control
+messages.
+
+### Control Message Types
+
+Every control message is a typed hyphence document. New fields are added without
+a version bump when they are optional; an incompatible change introduces a new
+type string (e.g. `-v2`), and both versions remain decodable, exactly as
+horizontal versioning prescribes. The defined types are:
+
+- `drtp-capabilities-v1` --- capability advertisement (both directions).
+- `drtp-want-v1` --- the requested query plus transfer options (client to
+  server for fetch; server to client for push).
+- `drtp-have-v1` --- object identities (with version digests) the receiver
+  already holds.
+- `drtp-blob_header-v1` --- announces the BLOB frame that follows.
+- `drtp-ack-v1` --- a phase acknowledgement (e.g. "objects received, here are
+  the blobs I still need" or "transfer complete").
+- `drtp-error-v1` --- a terminal error; carries a human-readable message and an
+  optional status code.
+
+Object batches are not a distinct control type: they are CONTROL frames of the
+repository's configured `inventory_list` type (e.g. `inventory_list-v2`),
+encoded by `inventory_list_coders.Closet` exactly as in on-disk and HTTP
+transfer. A receiver dispatches a CONTROL frame by its hyphence type string,
+so inventory-list frames and `drtp-*` frames coexist on the same channel.
+
+#### `drtp-capabilities-v1`
+
+Sent by each peer as its first frame. Body (TOML):
+
+    protocol-version   = 1
+    role               = "server"            # "server" | "client"
+    websocket          = true                # transport actually in use is ws
+    inventory-list-type = "inventory_list-v2"
+    hash-format        = "blake2b256"
+    expand-edges       = true                # sender computes closure
+    public-key         = "..."               # markl id, for attestation
+    nonce              = "..."               # challenge nonce (see Authentication)
+    signature          = "..."               # signature over peer's nonce
+
+`protocol-version` MUST be present. A peer that receives a `protocol-version` it
+does not support MUST reply with `drtp-error-v1` and close. The remaining fields
+are advertisements; a peer MUST ignore fields it does not understand (forward
+compatibility) and MUST NOT assume a feature is available unless the peer
+advertised it.
+
+The server's capabilities frame also carries its immutable public config as the
+bootstrap document, removing the separate `GET /config-immutable` round trip
+the HTTP backend requires: the field `immutable-config` holds the genesis config
+as a nested typed hyphence document (or the client MAY request it explicitly,
+see Fetch). [Implementation note: the reference implementation transmits the
+immutable config as its own CONTROL frame immediately after capabilities, which
+is simpler than nesting and keeps each frame a single typed blob.]
+
+### Authentication
+
+Authentication reuses the markl challenge/response of the HTTP backend, hoisted
+to once per session. In its `drtp-capabilities-v1` frame each peer includes a
+random `nonce`. Each peer's *next* frame (or the same frame, for the responder)
+includes a `signature` over the other peer's nonce, produced with the repo
+private key under purpose `PurposeRequestAuthResponseV1`, and its `public-key`.
+A peer verifies the signature against the advertised public key before
+proceeding. A client MAY pin the server's public key (rejecting a mismatch) or
+accept it Trust-On-First-Use.
+
+Object batches and blob payloads are content-addressed: every object carries its
+own markl object digest and every blob is validated against the markl ID in its
+`drtp-blob_header-v1`. A receiver MUST verify each blob's computed digest
+against the announced ID and MUST reject a mismatch. This gives the protocol the
+same end-to-end integrity the HTTP backend obtains from its body-digest trailer,
+without a per-frame signature.
+
+### Fetch (pull / clone)
+
+Fetch corresponds to git `upload-pack`: the *server* is the sender. The
+exchange is:
+
+1.  **Handshake.** Client and server exchange `drtp-capabilities-v1` and verify
+    authentication. The server sends its immutable config.
+
+2.  **Want.** The client sends `drtp-want-v1` carrying the query string (the
+    same doddish query the HTTP backend puts in `GET /query/...`) and the
+    transfer options (e.g. `allow-merge-conflicts`, `exclude-blobs`).
+
+3.  **Closure.** The server resolves the query to an inventory list of matching
+    object tips (`MakeInventoryList`), then runs expand-edges over that list to
+    obtain the full transitive closure: every dependency object (types, tags,
+    referenced objects, type-script-discovered objects) and every reachable blob
+    digest. This is the protocol's central use of the type system --- the sender
+    computes a self-consistent graph so the receiver never imports an object
+    whose type, tags, or referenced blobs are absent.
+
+4.  **Have (optional).** If the client advertised `have`, it sends one or more
+    `drtp-have-v1` frames enumerating the object identities and version digests
+    it already holds. The server omits those objects from the object stream and
+    omits blobs the client already has. Absent any `have`, the server sends the
+    whole closure (the clone case).
+
+5.  **Objects.** The server sends the closure's objects as one or more CONTROL
+    frames of the `inventory_list` type. The client imports them through the
+    ordinary importer (`ImportSeq` + `MakeImporter`), with the same merge /
+    conflict handling as a local pull.
+
+6.  **Blobs.** For each blob digest in the closure that the client lacks, the
+    server sends a `drtp-blob_header-v1` CONTROL frame followed by the BLOB
+    frame. The client validates the digest and writes the blob to its store.
+
+7.  **Done.** The server sends `drtp-ack-v1` with `status = "complete"`. Either
+    peer closes.
+
+Because the closure is computed once and streamed in a single direction, a
+fetch is one request/one response at the protocol level regardless of how many
+objects and blobs move --- the reactive `201`/`417` retry loop disappears.
+
+### Push (send)
+
+Push corresponds to git `receive-pack`: the *client* is the sender. It is the
+mirror of fetch:
+
+1.  Handshake (as above).
+2.  The client sends `drtp-want-v1` describing what it intends to push (its
+    query), so the server can apply receive-side policy.
+3.  The client computes the closure with expand-edges over its own store.
+4.  The server MAY send `drtp-have-v1` to tell the client which objects/blobs it
+    already has, so the client can skip them.
+5.  The client streams objects, then the blobs the server lacks.
+6.  The server imports and replies `drtp-ack-v1` (`status = "complete"`) or
+    `drtp-error-v1` (e.g. a rejected merge conflict).
+
+The existing CLI keeps its inverted-direction convention (push is a fetch with
+local and remote swapped); the protocol makes the direction explicit via the
+`role` capability and which peer sends `want`.
+
+### Blob Streaming
+
+A blob MAY be larger than the CONTROL frame maximum. The `drtp-blob_header-v1`
+frame carries the blob's total `length` and markl `id`. The blob bytes then
+follow as one BLOB frame whose `length` matches, OR --- when chunking is
+negotiated --- as a sequence of BLOB frames whose lengths sum to the header
+length, terminated by a zero-length BLOB frame. A receiver computes the blob
+digest incrementally and verifies it against the header `id` once the announced
+length is reached. Compression, if advertised in capabilities, is applied to the
+blob payload and MUST be reflected in a `compression` field on the header.
+
+### Versioning and Evolution
+
+The protocol's version surface is deliberately small:
+
+- `protocol-version` in `drtp-capabilities-v1` gates the overall exchange shape.
+- Every other message is a typed hyphence document, so a new field is a
+  non-breaking addition and a breaking change is a new type string with the old
+  one still decodable. This is the same horizontal-versioning discipline the
+  store uses for persisted blobs; the wire format gets it for free by reusing
+  hyphence coders.
+- The `inventory_list` type carried in object frames is the repository's
+  configured list type, so object encoding tracks the store version without the
+  protocol needing its own object schema.
+
+A peer MUST NOT remove support for decoding an older control type string when it
+bumps the protocol; old senders must remain understandable, mirroring the
+store's "never drop old codec support" rule.
+
+### Errors
+
+A terminal error is a `drtp-error-v1` CONTROL frame:
+
+    message     = "human readable description"
+    status-code = 409                          # optional, HTTP-status-like
+
+A peer that receives `drtp-error-v1` MUST surface the message and terminate the
+session. Transient transport errors (connection reset, timeout) are handled by
+the transport, not the protocol; a half-completed transfer leaves the receiver's
+store unchanged because imports are atomic per the store's existing semantics.
+
+### Security Considerations
+
+- **Authentication** is per-session markl challenge/response (see
+  Authentication); a public server (read-only) MAY waive the client's challenge
+  exactly as `remote_http`'s `Public` mode does, but MUST NOT waive it for a
+  push.
+- **Integrity** is content-addressing: objects carry their own digests and blobs
+  are verified against announced markl IDs. A man-in-the-middle cannot
+  substitute object or blob content without detection.
+- **Confidentiality** is the transport's responsibility. WebSocket transport
+  SHOULD run over TLS (`wss://`); the protocol does not encrypt payloads itself,
+  though blobs MAY already be encrypted at rest by the blob store.
+- **Resource exhaustion** is bounded by the frame maximum and by the receiver's
+  freedom to abort a session whose closure exceeds policy.
+
+### Compatibility and Migration
+
+`sierra/remote_http` is retained unchanged. The new protocol lives in
+`sierra/remote_proto`. A new remote connection type, `url-websocket`, selects
+the WebSocket transport; `serve` gains the `/drtp` endpoint when the new
+protocol is enabled. Existing remotes and the stdio/SSH/unix-socket/URL
+transports continue to use `remote_http` until repointed. Because WebSocket
+upgrade is optional and negotiated, a new client talking to an old server
+degrades to the HTTP backend rather than failing.
+
+## Resolved Decisions
+
+1.  **Typed hyphence docs as the wire format, not a bespoke pack.** Reusing
+    hyphence gives versioning, type dispatch, and signable/content-addressed
+    framing for free, and lets object batches be the exact inventory-list stream
+    the store already produces. A git-style binary packfile would be denser but
+    would duplicate machinery and forfeit free versioning.
+2.  **Sender-computed closure via expand-edges.** The sender, which has the
+    whole store, computes the transitive closure once. This removes the reactive
+    missing-blob loop and guarantees referential completeness, matching what the
+    local-to-local pull already does.
+3.  **Length-prefixed frames over hyphence boundaries as the outer container.**
+    Avoids unbounded boundary scanning and lets opaque blob bytes share the
+    channel with control messages.
+4.  **Optional, negotiated WebSocket upgrade.** WebSocket is one transport among
+    several; the protocol is defined over a byte stream so the same session code
+    runs over stdio, sockets, TCP, and WebSocket. A failed upgrade degrades to
+    the HTTP backend.
+5.  **Hard fork, coexistence.** `remote_http` stays; `remote_proto` is new. No
+    behavior change for existing deployments until they opt in.
+
+## Open Questions
+
+- **Capability-driven auto-upgrade from a stored remote.** Whether a remote
+  stored as a plain `url` should probe `/drtp` and silently upgrade, or whether
+  the WebSocket transport must be selected explicitly via `url-websocket`. v1
+  selects it explicitly; auto-probing is deferred.
+- **Multiplexing multiple transfers per session.** v1 is one transfer per
+  session. A future version MAY add stream IDs to frames to allow concurrent
+  fetch and push, at the cost of framing complexity.
+- **Delta encoding of objects/blobs.** git sends deltas; v1 sends whole objects
+  and whole blobs (deduplicated by content address). Delta transfer is deferred.
+
+## More Information
+
+- RFC 0001: Hyphence Format --- the wire representation for every message.
+- RFC 0002: Markl ID Format --- addressing, locks, and signatures.
+- `docs/plans/2026-03-21-edge-explorer-design.md` --- the expand-edges design
+  the closure computation builds on.

--- a/docs/rfcs/0004-remote-transfer-protocol.md
+++ b/docs/rfcs/0004-remote-transfer-protocol.md
@@ -152,9 +152,11 @@ Two frame kinds are defined:
 
 - `kind = 0x01` **CONTROL**: the payload is a single typed hyphence document
   (RFC 0001) whose type string is one of the control types below.
-- `kind = 0x02` **BLOB**: the payload is the raw bytes of one content-addressed
-  blob. A BLOB frame MUST be immediately preceded by a CONTROL frame of type
-  `drtp-blob_header-v1` naming the blob's markl ID and byte length.
+- `kind = 0x02` **BLOB**: the payload is a chunk of the raw bytes of one
+  content-addressed blob. A blob is sent as a CONTROL frame of type
+  `drtp-blob_header-v1` naming the blob's markl ID, followed by one or more
+  BLOB frames carrying its bytes, terminated by a zero-length BLOB frame. A
+  blob is never required to be buffered whole on either side.
 
 A receiver MUST reject a frame whose `length` exceeds a configured maximum
 (RECOMMENDED default 64 MiB for CONTROL frames; BLOB frames are bounded by the
@@ -306,14 +308,15 @@ local and remote swapped); the protocol makes the direction explicit via the
 
 ### Blob Streaming
 
-A blob MAY be larger than the CONTROL frame maximum. The `drtp-blob_header-v1`
-frame carries the blob's total `length` and markl `id`. The blob bytes then
-follow as one BLOB frame whose `length` matches, OR --- when chunking is
-negotiated --- as a sequence of BLOB frames whose lengths sum to the header
-length, terminated by a zero-length BLOB frame. A receiver computes the blob
-digest incrementally and verifies it against the header `id` once the announced
-length is reached. Compression, if advertised in capabilities, is applied to the
-blob payload and MUST be reflected in a `compression` field on the header.
+Blobs are always streamed, never buffered whole. The `drtp-blob_header-v1`
+frame carries the blob's markl `id`; its bytes then follow as a sequence of
+BLOB frames terminated by a zero-length BLOB frame. The header carries no
+length --- the terminator delimits the blob --- so a blob of any size moves with
+constant memory on both sides. A receiver writes each chunk to the blob store
+as it arrives, computes the content digest incrementally, and verifies it
+against the header `id` after the terminator; a mismatch aborts the transfer.
+Compression, if advertised in capabilities, is applied to the chunk payloads
+and MUST be reflected in a `compression` field on the header.
 
 ### Versioning and Evolution
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -5,6 +5,7 @@ go 1.26.2
 require (
 	code.linenisgreat.com/chrest/go v0.2.0
 	filippo.io/age v1.3.1
+	github.com/DataDog/zstd v1.5.7
 	github.com/amarbel-llc/madder/go v0.3.31-0.20260531165016-00613b378127
 	github.com/amarbel-llc/purse-first/libs/dewey v0.2.6-0.20260530121752-67a6f4d5e72d
 	github.com/amarbel-llc/purse-first/libs/go-mcp v0.2.6-0.20260530121752-67a6f4d5e72d
@@ -32,7 +33,6 @@ require (
 require (
 	filippo.io/edwards25519 v1.2.0 // indirect
 	filippo.io/hpke v0.4.0 // indirect
-	github.com/DataDog/zstd v1.5.7 // indirect
 	github.com/akutz/memconn v0.1.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.7 // indirect

--- a/go/go.mod
+++ b/go/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/brandondube/tai v0.1.0
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/coder/websocket v1.8.14
 	github.com/google/go-cmp v0.7.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.6.0
@@ -63,7 +64,6 @@ require (
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
-	github.com/coder/websocket v1.8.14 // indirect
 	github.com/dblohm7/wingoes v0.0.0-20250822163801-6d8e6105c62d // indirect
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/go/internal/0/remote_connection_types/main.go
+++ b/go/internal/0/remote_connection_types/main.go
@@ -17,6 +17,10 @@ const (
 	TypeUrl
 	TypeStdioLocal
 	TypeStdioSSH
+	// TypeUrlWebsocket selects the drtp websocket transport
+	// (sierra/remote_proto), upgrading an HTTP url remote to a websocket
+	// session. See docs/rfcs/0004-remote-transfer-protocol.md.
+	TypeUrlWebsocket
 	_TypeMax
 )
 
@@ -53,6 +57,7 @@ func (tipe *Type) GetCLICompletion() map[string]string {
 		"stdio-ssh":         "",
 		"unspecified":       "",
 		"url":               "",
+		"url-websocket":     "",
 	}
 }
 
@@ -73,6 +78,9 @@ func (tipe *Type) Set(value string) (err error) {
 
 	case "url":
 		*tipe = TypeUrl
+
+	case "url-websocket":
+		*tipe = TypeUrlWebsocket
 
 	case "stdio-local":
 		*tipe = TypeStdioLocal

--- a/go/internal/0/remote_connection_types/type_string.go
+++ b/go/internal/0/remote_connection_types/type_string.go
@@ -15,12 +15,13 @@ func _() {
 	_ = x[TypeUrl-4]
 	_ = x[TypeStdioLocal-5]
 	_ = x[TypeStdioSSH-6]
-	_ = x[_TypeMax-7]
+	_ = x[TypeUrlWebsocket-7]
+	_ = x[_TypeMax-8]
 }
 
-const _Type_name = "TypeUnspecifiedTypeNativeTypeNativeLocalOverridePathTypeSocketUnixTypeUrlTypeStdioLocalTypeStdioSSH_TypeMax"
+const _Type_name = "TypeUnspecifiedTypeNativeTypeNativeLocalOverridePathTypeSocketUnixTypeUrlTypeStdioLocalTypeStdioSSHTypeUrlWebsocket_TypeMax"
 
-var _Type_index = [...]uint8{0, 15, 25, 52, 66, 73, 87, 99, 107}
+var _Type_index = [...]uint8{0, 15, 25, 52, 66, 73, 87, 99, 115, 123}
 
 func (i Type) String() string {
 	idx := int(i) - 0

--- a/go/internal/sierra/remote_proto/CLAUDE.md
+++ b/go/internal/sierra/remote_proto/CLAUDE.md
@@ -60,6 +60,14 @@ transport so it can ride a websocket.
   subset it already has); the sender streams only the rest. Both
   `sendClosure`/`receiveClosure` perform this exchange before the blob/object
   frames, so the reads stay in lockstep regardless of direction.
+- **Blob compression (zstd) is negotiated in capabilities.** Each peer
+  advertises `supportedCompression`; the *sender* calls `negotiateCompression`
+  on the peer's advertised value and, when both agree, compresses each blob's
+  chunk stream through `DataDog/zstd` (the dodder/madder zstd lib, already in
+  the build closure — cgo). The digest is verified over the **decompressed**
+  bytes, so content addressing is unaffected. `blobFrameWriter` /
+  `blobFrameReader` (session.go) adapt the frame stream to the
+  encoder/decoder.
 
 ## CLI surface
 

--- a/go/internal/sierra/remote_proto/CLAUDE.md
+++ b/go/internal/sierra/remote_proto/CLAUDE.md
@@ -1,0 +1,69 @@
+# remote_proto
+
+The drtp remote transfer protocol: a session protocol that streams a
+sender-computed expand-edges closure, optionally over a websocket. It is a
+**hard fork** of `sierra/remote_http` (which is retained and unchanged); the
+two coexist. Specified in `docs/rfcs/0004-remote-transfer-protocol.md`.
+
+## Why a fork
+
+`remote_http` is reactive (REST calls + a missing-blob retry loop), has no
+version negotiation, and re-handshakes per request. drtp handshakes once per
+session, negotiates capabilities, computes the whole transfer up front with
+the type system's `expand-edges`, and is framed independently of any one
+transport so it can ride a websocket.
+
+## Layers (bottom to top)
+
+- `protocol.go` — version, frame kinds, control type strings, constants.
+- `frame.go` — length-prefixed frames: `[kind:1][len:uint32 BE][payload]`.
+- `control.go` — control messages: one `control` envelope encoded as a typed
+  hyphence document (`! drtp-*-v1` metadata + JSON body). Dispatch is by the
+  hyphence type string.
+- `auth.go` / `handshake.go` — per-session markl challenge/response, reusing
+  the same purposes as remote_http. `handshake.go` is decoupled from
+  `*local_working_copy.Repo` (takes a `keys` struct) so it is unit-tested
+  with generated keys.
+- `session.go` — buffered framing over an `io.ReadWriteCloser`.
+- `edges.go` — `expandEdges`, a fork of `local_working_copy.expandEdges`,
+  driving `store.MakeEdgeExplorer` to compute the transitive closure.
+- `transfer.go` — `sendClosure` (sender) / `receiveClosure` (receiver). The
+  sender streams blobs first, then the object batch, then a completion ack.
+- `server.go` / `client.go` — repo-backed wrappers. `Server.ServeConn` runs
+  one session; `Client.Fetch` / `Client.Push` initiate one.
+- `transport_websocket.go` — `Server.Serve` (HTTP listener, `/drtp` upgrade,
+  `/healthz`), `Server.ServeStdio`, and `DialWebSocket`. Uses
+  `coder/websocket` + `websocket.NetConn` to present the upgraded connection
+  as a `net.Conn`, so the same session code runs over websocket, stdio, TCP,
+  and the in-memory `net.Pipe` used by the tests.
+
+## Gotchas learned the hard way
+
+- **Object batches MUST use the *typed* writer.** `sendObjects` calls
+  `Closet.WriteTypedBlobToWriter` (not `WriteBlobToWriter`) so the stream
+  carries its `! inventory_list-vN` line; the receiver's
+  `AllDecodedObjectsFromStream` reads that type to pick the decoder. Using
+  the untyped writer yields `no coders available for type: ""` on import.
+- **Never `errors.Wrap` a bare `io.EOF`** (the dewey errors package panics).
+  Frame readers return raw `io.EOF`; `readControlExpecting` converts it to a
+  descriptive error before any wrap.
+- **Disable the websocket read limit** (`conn.SetReadLimit(-1)`) on both ends
+  — a flushed objects/blob frame can exceed the 32 KiB default message size.
+- **Blobs stream before objects** so the importer finds every blob already on
+  disk; no `RemoteBlobStore` is wired into the receiver's importer.
+
+## CLI surface
+
+- `serve-proto [network] [address]` (`commands_dodder/serve_proto.go`) —
+  `-public`, `-handshake`, `-` for stdio.
+- `remote_connection_types.TypeUrlWebsocket` (`url-websocket`) — selects this
+  backend in `pull`/`push` via `-remote-connection-type`. `remote-add`
+  registers a websocket url remote Trust-On-First-Use (no connect at add
+  time, since serve-proto does not serve the remote_http REST surface).
+
+## Tests
+
+`*_test.go` here run with plain `go test` (no repo needed): control/frame
+round-trips, the markl auth handshake over `net.Pipe`, and a full handshake
+over a real websocket via `httptest`. End-to-end pull/push over websocket is
+covered by `zz-tests_bats/current_version/serve_proto.bats`.

--- a/go/internal/sierra/remote_proto/CLAUDE.md
+++ b/go/internal/sierra/remote_proto/CLAUDE.md
@@ -51,6 +51,15 @@ transport so it can ride a websocket.
   — a flushed objects/blob frame can exceed the 32 KiB default message size.
 - **Blobs stream before objects** so the importer finds every blob already on
   disk; no `RemoteBlobStore` is wired into the receiver's importer.
+- **Blobs are streamed in chunks, never buffered whole.** `session.writeBlob`
+  emits a `blob_header` then `blobChunkSize` BLOB frames ended by a zero-length
+  terminator; `recvBlob` copies chunks straight into the blob writer and
+  verifies the digest after the terminator. The header carries no length.
+- **Have-negotiation precedes the stream.** The sender sends `drtp-manifest-v1`
+  (every closure blob it holds); the receiver replies `drtp-have-v1` (the
+  subset it already has); the sender streams only the rest. Both
+  `sendClosure`/`receiveClosure` perform this exchange before the blob/object
+  frames, so the reads stay in lockstep regardless of direction.
 
 ## CLI surface
 

--- a/go/internal/sierra/remote_proto/auth.go
+++ b/go/internal/sierra/remote_proto/auth.go
@@ -1,0 +1,101 @@
+package remote_proto
+
+import (
+	mad_domain_interfaces "github.com/amarbel-llc/madder/go/pkgs/domain_interfaces"
+	"github.com/amarbel-llc/madder/go/pkgs/markl"
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/errors"
+)
+
+// Authentication reuses remote_http's markl challenge/response, hoisted to
+// once per session (see the RFC, "Authentication"). Each peer advertises a
+// random nonce in its capabilities frame; each peer signs the other's nonce
+// with its repo private key and returns the signature plus its public key.
+// A peer verifies the signature against the advertised public key before
+// trusting the connection.
+
+// generateNonce mints a fresh challenge nonce, matching the
+// RoundTripperBufioWrappedSigner nonce in remote_http.
+func generateNonce() (nonceString string, err error) {
+	var nonce markl.Id
+
+	if err = nonce.GeneratePrivateKey(
+		nil,
+		markl.FormatIdNonceSec,
+		markl.PurposeRequestAuthChallengeV1,
+	); err != nil {
+		err = errors.Wrap(err)
+		return nonceString, err
+	}
+
+	return nonce.String(), err
+}
+
+// signNonce signs the peer's nonce with priv under the same purpose
+// remote_http uses for its challenge response.
+func signNonce(
+	priv mad_domain_interfaces.MarklId,
+	nonceString string,
+) (sigString string, err error) {
+	var nonce markl.Id
+
+	if err = nonce.Set(nonceString); err != nil {
+		err = errors.Wrap(err)
+		return sigString, err
+	}
+
+	var sig markl.Id
+
+	if err = priv.Sign(
+		nonce,
+		&sig,
+		markl.PurposeRequestAuthResponseV1,
+	); err != nil {
+		err = errors.Wrap(err)
+		return sigString, err
+	}
+
+	return sig.String(), err
+}
+
+// verifyNonceSignature verifies that sigString is a signature over
+// nonceString produced by the private key matching pubKeyString. An empty
+// pubKeyString or sigString is treated as "no attestation offered" and
+// returns errNoAttestation so the caller can decide whether that is
+// acceptable (e.g. a public read server).
+func verifyNonceSignature(
+	pubKeyString, nonceString, sigString string,
+) (err error) {
+	if pubKeyString == "" || sigString == "" {
+		return errNoAttestation
+	}
+
+	var pubKey markl.Id
+
+	if err = pubKey.Set(pubKeyString); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	var nonce markl.Id
+
+	if err = nonce.Set(nonceString); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	var sig markl.Id
+
+	if err = sig.Set(sigString); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	if err = pubKey.Verify(nonce, sig); err != nil {
+		err = errors.Wrapf(err, "challenge signature verification failed")
+		return err
+	}
+
+	return err
+}
+
+var errNoAttestation = errors.Errorf("peer offered no attestation")

--- a/go/internal/sierra/remote_proto/blob_stream_test.go
+++ b/go/internal/sierra/remote_proto/blob_stream_test.go
@@ -6,8 +6,52 @@ import (
 	"net"
 	"testing"
 
+	"github.com/DataDog/zstd"
 	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/ui"
 )
+
+// TestBlobStreamZstdRoundTrip verifies a zstd-compressed blob streams as
+// frames and decompresses, via blobFrameReader, back to the original bytes —
+// and that the wire bytes are actually fewer than the payload.
+func TestBlobStreamZstdRoundTrip(t1 *testing.T) {
+	t := ui.MakeT(t1)
+
+	clientConn, serverConn := net.Pipe()
+
+	// Highly compressible payload, larger than one chunk.
+	payload := bytes.Repeat([]byte("aaaabbbbcccc"), 30000)
+
+	writeErr := make(chan error, 1)
+
+	go func() {
+		sw := makeSession(clientConn)
+		writeErr <- sw.writeBlob("blake2b256-zstd", bytes.NewReader(payload), CompressionZstd)
+		_ = clientConn.Close()
+	}()
+
+	sr := makeSession(serverConn)
+
+	typeString, header, err := sr.readControl()
+	t.AssertNoError(err)
+	t.AssertEqual("!"+TypeBlobHeader, typeString)
+	t.AssertEqual(CompressionZstd, header.Compression)
+
+	frameReader := &blobFrameReader{session: sr}
+	decoder := zstd.NewReader(frameReader)
+
+	var got bytes.Buffer
+
+	if _, err = io.Copy(&got, decoder); err != nil {
+		t.Fatalf("decompressing: %v", err)
+	}
+
+	t.AssertNoError(decoder.Close())
+	t.AssertNoError(<-writeErr)
+
+	if !bytes.Equal(payload, got.Bytes()) {
+		t.Fatalf("decompressed blob differs from original")
+	}
+}
 
 // TestBlobStreamRoundTrip verifies writeBlob chunks a blob larger than one
 // frame into multiple blob frames terminated by a zero-length frame, and that
@@ -24,7 +68,7 @@ func TestBlobStreamRoundTrip(t1 *testing.T) {
 
 	go func() {
 		sw := makeSession(clientConn)
-		writeErr <- sw.writeBlob("blake2b256-test", bytes.NewReader(payload))
+		writeErr <- sw.writeBlob("blake2b256-test", bytes.NewReader(payload), CompressionNone)
 		_ = clientConn.Close()
 	}()
 
@@ -77,7 +121,7 @@ func TestBlobStreamEmpty(t1 *testing.T) {
 
 	go func() {
 		sw := makeSession(clientConn)
-		writeErr <- sw.writeBlob("blake2b256-empty", bytes.NewReader(nil))
+		writeErr <- sw.writeBlob("blake2b256-empty", bytes.NewReader(nil), CompressionNone)
 		_ = clientConn.Close()
 	}()
 

--- a/go/internal/sierra/remote_proto/blob_stream_test.go
+++ b/go/internal/sierra/remote_proto/blob_stream_test.go
@@ -1,0 +1,96 @@
+package remote_proto
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/ui"
+)
+
+// TestBlobStreamRoundTrip verifies writeBlob chunks a blob larger than one
+// frame into multiple blob frames terminated by a zero-length frame, and that
+// the chunks reassemble to the original bytes.
+func TestBlobStreamRoundTrip(t1 *testing.T) {
+	t := ui.MakeT(t1)
+
+	clientConn, serverConn := net.Pipe()
+
+	// Larger than blobChunkSize so the blob spans several frames.
+	payload := bytes.Repeat([]byte("dodder-blob-payload-"), 20000)
+
+	writeErr := make(chan error, 1)
+
+	go func() {
+		sw := makeSession(clientConn)
+		writeErr <- sw.writeBlob("blake2b256-test", bytes.NewReader(payload))
+		_ = clientConn.Close()
+	}()
+
+	sr := makeSession(serverConn)
+
+	typeString, header, err := sr.readControl()
+	t.AssertNoError(err)
+	t.AssertEqual("!"+TypeBlobHeader, typeString)
+	t.AssertEqual("blake2b256-test", header.BlobId)
+
+	var got bytes.Buffer
+	frameCount := 0
+
+	for {
+		kind, length, frameErr := readFrameHeader(sr.reader)
+		t.AssertNoError(frameErr)
+		t.AssertEqual(frameKindBlob, kind)
+
+		if length == 0 {
+			break
+		}
+
+		frameCount++
+
+		if _, err = io.CopyN(&got, sr.reader, int64(length)); err != nil {
+			t.Fatalf("copying chunk: %v", err)
+		}
+	}
+
+	t.AssertNoError(<-writeErr)
+	t.AssertEqual(len(payload), got.Len())
+
+	if !bytes.Equal(payload, got.Bytes()) {
+		t.Fatalf("reassembled blob differs from original")
+	}
+
+	if frameCount < 2 {
+		t.Fatalf("expected the blob to span multiple frames, got %d", frameCount)
+	}
+}
+
+// TestBlobStreamEmpty verifies a zero-byte blob is a header followed
+// immediately by the terminator frame.
+func TestBlobStreamEmpty(t1 *testing.T) {
+	t := ui.MakeT(t1)
+
+	clientConn, serverConn := net.Pipe()
+
+	writeErr := make(chan error, 1)
+
+	go func() {
+		sw := makeSession(clientConn)
+		writeErr <- sw.writeBlob("blake2b256-empty", bytes.NewReader(nil))
+		_ = clientConn.Close()
+	}()
+
+	sr := makeSession(serverConn)
+
+	typeString, _, err := sr.readControl()
+	t.AssertNoError(err)
+	t.AssertEqual("!"+TypeBlobHeader, typeString)
+
+	kind, length, frameErr := readFrameHeader(sr.reader)
+	t.AssertNoError(frameErr)
+	t.AssertEqual(frameKindBlob, kind)
+	t.AssertEqual(uint32(0), length)
+
+	t.AssertNoError(<-writeErr)
+}

--- a/go/internal/sierra/remote_proto/client.go
+++ b/go/internal/sierra/remote_proto/client.go
@@ -1,0 +1,147 @@
+package remote_proto
+
+import (
+	"io"
+
+	"code.linenisgreat.com/dodder/go/internal/bravo/env_ui"
+	"code.linenisgreat.com/dodder/go/internal/foxtrot/sku"
+	"code.linenisgreat.com/dodder/go/internal/papa/repo"
+	"code.linenisgreat.com/dodder/go/internal/romeo/local_working_copy"
+	mad_domain_interfaces "github.com/amarbel-llc/madder/go/pkgs/domain_interfaces"
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/errors"
+)
+
+// Client drives the initiating half of the drtp protocol against a peer
+// reached over conn. It is the hard-fork counterpart of remote_http's
+// client; the two coexist.
+type Client struct {
+	env   env_ui.Env
+	local *local_working_copy.Repo
+
+	// PinnedPublicKey, when set, rejects a server whose advertised public
+	// key does not match (vs. Trust-On-First-Use when nil).
+	PinnedPublicKey mad_domain_interfaces.MarklId
+}
+
+func MakeClient(local *local_working_copy.Repo) *Client {
+	return &Client{
+		env:   local.GetEnv(),
+		local: local,
+	}
+}
+
+func (client *Client) keys() keys {
+	return keys{
+		private: client.local.GetImmutableConfigPrivate().Blob.GetPrivateKey(),
+		public:  client.local.GetImmutableConfigPublic().GetPublicKey(),
+	}
+}
+
+func (client *Client) listType() string {
+	return client.local.GetImmutableConfigPublic().GetInventoryListTypeId()
+}
+
+// Fetch pulls every object matching query (and its expand-edges closure)
+// from the peer on conn into the local repo. Closes conn when done.
+func (client *Client) Fetch(
+	conn io.ReadWriteCloser,
+	query string,
+	options repo.ImporterOptions,
+) (err error) {
+	s := makeSession(conn)
+	defer errors.DeferredCloser(&err, s)
+
+	var serverCaps control
+
+	if serverCaps, _, err = clientHandshake(
+		s,
+		client.keys(),
+		client.listType(),
+		client.PinnedPublicKey,
+	); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	var want control
+
+	if want, err = signWant(client.keys(), serverCaps.Nonce, control{
+		Direction:           DirectionFetch,
+		Query:               query,
+		AllowMergeConflicts: options.AllowMergeConflicts,
+		ExcludeBlobs:        options.ExcludeBlobs,
+	}); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	if err = s.writeControl(TypeWant, want); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	if err = receiveClosure(
+		client.env,
+		s,
+		client.local,
+		want,
+		sku.GetStoreOptionsImport(),
+	); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	return err
+}
+
+// Push sends every local object matching query (and its closure) to the
+// peer on conn. Closes conn when done.
+func (client *Client) Push(
+	conn io.ReadWriteCloser,
+	query string,
+	options repo.ImporterOptions,
+) (err error) {
+	s := makeSession(conn)
+	defer errors.DeferredCloser(&err, s)
+
+	var serverCaps control
+
+	if serverCaps, _, err = clientHandshake(
+		s,
+		client.keys(),
+		client.listType(),
+		client.PinnedPublicKey,
+	); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	var want control
+
+	if want, err = signWant(client.keys(), serverCaps.Nonce, control{
+		Direction:    DirectionPush,
+		Query:        query,
+		ExcludeBlobs: options.ExcludeBlobs,
+	}); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	if err = s.writeControl(TypeWant, want); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	if err = sendClosure(
+		client.env,
+		s,
+		client.local,
+		client.local.GetEnvRepo(),
+		want,
+	); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	return err
+}

--- a/go/internal/sierra/remote_proto/client.go
+++ b/go/internal/sierra/remote_proto/client.go
@@ -138,6 +138,7 @@ func (client *Client) Push(
 		client.local,
 		client.local.GetEnvRepo(),
 		want,
+		negotiateCompression(serverCaps.Compression),
 	); err != nil {
 		err = errors.Wrap(err)
 		return err

--- a/go/internal/sierra/remote_proto/control.go
+++ b/go/internal/sierra/remote_proto/control.go
@@ -40,7 +40,11 @@ type control struct {
 	AllowMergeConflicts bool   `json:"allow_merge_conflicts,omitempty"`
 	ExcludeBlobs        bool   `json:"exclude_blobs,omitempty"`
 
-	// have
+	// manifest: every blob digest the sender holds for this transfer
+	Blobs []string `json:"blobs,omitempty"`
+
+	// have: the subset of the manifest the receiver already holds (and so
+	// the sender SHOULD NOT stream)
 	Objects   []string `json:"objects,omitempty"`
 	HaveBlobs []string `json:"have_blobs,omitempty"`
 
@@ -97,6 +101,7 @@ func makeControlBlobCoders() map[string]interfaces.CoderBufferedReadWriter[*cont
 	for _, typeString := range []string{
 		TypeCapabilities,
 		TypeWant,
+		TypeManifest,
 		TypeHave,
 		TypeBlobHeader,
 		TypeAck,

--- a/go/internal/sierra/remote_proto/control.go
+++ b/go/internal/sierra/remote_proto/control.go
@@ -1,0 +1,149 @@
+package remote_proto
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"code.linenisgreat.com/dodder/go/internal/bravo/ids"
+	"github.com/amarbel-llc/madder/go/pkgs/hyphence"
+	mad_ids "github.com/amarbel-llc/madder/go/pkgs/ids"
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/errors"
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/interfaces"
+)
+
+// control is the single envelope carrying every drtp control message. The
+// hyphence type of the frame (one of the Type* strings) selects the
+// message's meaning; only the fields relevant to that type are populated.
+// A single envelope keeps decode-time dispatch trivial: read the hyphence
+// type, then switch — no per-type Go struct or speculative decode.
+//
+// The body is JSON (stdlib, dependency-free, and well-precedented here —
+// server_mcp.go speaks JSON-RPC) wrapped in hyphence typed-document
+// framing, so the message is a typed hyphence doc on the wire while the
+// implementation avoids pulling a TOML codec into the nix build closure.
+type control struct {
+	// capabilities
+	ProtocolVersion   int    `json:"protocol_version,omitempty"`
+	Role              string `json:"role,omitempty"`
+	WebSocket         bool   `json:"websocket,omitempty"`
+	InventoryListType string `json:"inventory_list_type,omitempty"`
+	HashFormat        string `json:"hash_format,omitempty"`
+	ExpandEdges       bool   `json:"expand_edges,omitempty"`
+	Public            bool   `json:"public,omitempty"`
+	PublicKey         string `json:"public_key,omitempty"`
+	Nonce             string `json:"nonce,omitempty"`
+	Signature         string `json:"signature,omitempty"`
+
+	// want
+	Direction           string `json:"direction,omitempty"`
+	Query               string `json:"query,omitempty"`
+	AllowMergeConflicts bool   `json:"allow_merge_conflicts,omitempty"`
+	ExcludeBlobs        bool   `json:"exclude_blobs,omitempty"`
+
+	// have
+	Objects   []string `json:"objects,omitempty"`
+	HaveBlobs []string `json:"have_blobs,omitempty"`
+
+	// blob_header
+	BlobId      string `json:"blob_id,omitempty"`
+	BlobLength  int64  `json:"blob_length,omitempty"`
+	Compression string `json:"compression,omitempty"`
+
+	// ack
+	Status string `json:"status,omitempty"`
+
+	// error
+	Message    string `json:"message,omitempty"`
+	StatusCode int    `json:"status_code,omitempty"`
+}
+
+// controlCoder encodes/decodes a control envelope as a typed hyphence
+// document. Every known control type maps to the same JSON body coder; the
+// type lives in the hyphence metadata line and is the single source of
+// truth for dispatch.
+var controlCoder = hyphence.CoderToTypedBlob[control]{
+	Metadata: hyphence.TypedMetadataCoder[control]{},
+	Blob:     hyphence.CoderTypeMapWithoutType[control](makeControlBlobCoders()),
+}
+
+func makeControlBlobCoders() map[string]interfaces.CoderBufferedReadWriter[*control] {
+	jsonCoder := hyphence.CoderTommy[control, *control]{
+		Decode: func(b []byte) (msg control, err error) {
+			// An empty body is a valid message whose meaning is carried
+			// entirely by its type (e.g. a bare ack).
+			if len(bytes.TrimSpace(b)) == 0 {
+				return msg, err
+			}
+
+			if err = json.Unmarshal(b, &msg); err != nil {
+				err = errors.Wrap(err)
+				return msg, err
+			}
+
+			return msg, err
+		},
+		Encode: func(msg control) (b []byte, err error) {
+			if b, err = json.Marshal(msg); err != nil {
+				err = errors.Wrap(err)
+				return b, err
+			}
+
+			return b, err
+		},
+	}
+
+	coders := make(map[string]interfaces.CoderBufferedReadWriter[*control])
+
+	for _, typeString := range []string{
+		TypeCapabilities,
+		TypeWant,
+		TypeHave,
+		TypeBlobHeader,
+		TypeAck,
+		TypeError,
+	} {
+		// Key on exactly what TypedBlob.Type.String() will produce so the
+		// lookup in CoderTypeMapWithoutType matches regardless of the
+		// "!"-prefix convention.
+		coders[madType(typeString).String()] = jsonCoder
+	}
+
+	return coders
+}
+
+// madType builds the madder hyphence TypeStruct for a drtp control type
+// string.
+func madType(typeString string) mad_ids.TypeStruct {
+	return ids.MustTypeStruct(typeString).ToMadder()
+}
+
+// encodeControl writes a control message of the given type to a byte slice
+// as a typed hyphence document.
+func encodeControl(typeString string, msg control) (b []byte, err error) {
+	typedBlob := &hyphence.TypedBlob[control]{
+		Type: madType(typeString),
+		Blob: msg,
+	}
+
+	var buffer bytes.Buffer
+
+	if _, err = controlCoder.EncodeTo(typedBlob, &buffer); err != nil {
+		err = errors.Wrap(err)
+		return b, err
+	}
+
+	return buffer.Bytes(), err
+}
+
+// decodeControl parses a typed hyphence control document, returning its
+// type string (with the leading "!") and the decoded envelope.
+func decodeControl(b []byte) (typeString string, msg control, err error) {
+	typedBlob := &hyphence.TypedBlob[control]{}
+
+	if _, err = controlCoder.DecodeFrom(typedBlob, bytes.NewReader(b)); err != nil {
+		err = errors.Wrap(err)
+		return typeString, msg, err
+	}
+
+	return typedBlob.Type.String(), typedBlob.Blob, err
+}

--- a/go/internal/sierra/remote_proto/control_test.go
+++ b/go/internal/sierra/remote_proto/control_test.go
@@ -1,0 +1,92 @@
+package remote_proto
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/ui"
+)
+
+func TestControlRoundTrip(t1 *testing.T) {
+	t := ui.MakeT(t1)
+
+	original := control{
+		ProtocolVersion:   ProtocolVersion,
+		Role:              RoleServer,
+		WebSocket:         true,
+		InventoryListType: "inventory_list-v2",
+		ExpandEdges:       true,
+		PublicKey:         "some-public-key",
+		Nonce:             "some-nonce",
+	}
+
+	encoded, err := encodeControl(TypeCapabilities, original)
+	t.AssertNoError(err)
+
+	// The encoded payload must be a typed hyphence document carrying the
+	// type in its metadata line.
+	if !bytes.Contains(encoded, []byte("! "+TypeCapabilities)) {
+		t.Fatalf("encoded control missing type line: %q", encoded)
+	}
+
+	typeString, decoded, err := decodeControl(encoded)
+	t.AssertNoError(err)
+	t.AssertEqual("!"+TypeCapabilities, typeString)
+	t.AssertEqual(original.ProtocolVersion, decoded.ProtocolVersion)
+	t.AssertEqual(original.Role, decoded.Role)
+	t.AssertEqual(original.WebSocket, decoded.WebSocket)
+	t.AssertEqual(original.InventoryListType, decoded.InventoryListType)
+	t.AssertEqual(original.PublicKey, decoded.PublicKey)
+	t.AssertEqual(original.Nonce, decoded.Nonce)
+}
+
+func TestControlBareAck(t1 *testing.T) {
+	t := ui.MakeT(t1)
+
+	encoded, err := encodeControl(TypeAck, control{Status: StatusComplete})
+	t.AssertNoError(err)
+
+	typeString, decoded, err := decodeControl(encoded)
+	t.AssertNoError(err)
+	t.AssertEqual("!"+TypeAck, typeString)
+	t.AssertEqual(StatusComplete, decoded.Status)
+}
+
+func TestFrameRoundTrip(t1 *testing.T) {
+	t := ui.MakeT(t1)
+
+	var buffer bytes.Buffer
+
+	t.AssertNoError(
+		writeControlFrame(&buffer, TypeWant, control{
+			Direction: DirectionFetch,
+			Query:     ":z",
+		}),
+	)
+
+	payload := []byte("raw blob bytes")
+	t.AssertNoError(writeFrame(&buffer, frameKindBlob, payload))
+
+	// First frame: the want control.
+	kind, length, err := readFrameHeader(&buffer)
+	t.AssertNoError(err)
+	t.AssertEqual(frameKindControl, kind)
+
+	got, err := readFramePayload(&buffer, length)
+	t.AssertNoError(err)
+
+	typeString, msg, err := decodeControl(got)
+	t.AssertNoError(err)
+	t.AssertEqual("!"+TypeWant, typeString)
+	t.AssertEqual(DirectionFetch, msg.Direction)
+	t.AssertEqual(":z", msg.Query)
+
+	// Second frame: the raw blob.
+	kind, length, err = readFrameHeader(&buffer)
+	t.AssertNoError(err)
+	t.AssertEqual(frameKindBlob, kind)
+
+	got, err = readFramePayload(&buffer, length)
+	t.AssertNoError(err)
+	t.AssertEqual(string(payload), string(got))
+}

--- a/go/internal/sierra/remote_proto/edges.go
+++ b/go/internal/sierra/remote_proto/edges.go
@@ -1,0 +1,96 @@
+package remote_proto
+
+import (
+	"code.linenisgreat.com/dodder/go/internal/bravo/ids"
+	"code.linenisgreat.com/dodder/go/internal/foxtrot/sku"
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/errors"
+)
+
+// maxEdgeExpansionDepth bounds the closure traversal, matching
+// local_working_copy's expandEdges.
+const maxEdgeExpansionDepth = 5
+
+// expandEdges grows list into the transitive closure of its objects: every
+// dependency object (type, tags, referenced objects, and type-script
+// discovered objects) is fetched from objectStore and added to list, while
+// every reachable blob digest is accumulated into allEdges.Blobs.
+//
+// This is the protocol's central use of the type system: the sender — which
+// holds the whole store — computes a self-consistent object graph once, so
+// the receiver never imports an object whose type, tags, or referenced
+// blobs are absent. It is a near-verbatim fork of
+// local_working_copy.expandEdges, hoisted here so the remote sender drives
+// the same traversal the local-to-local pull already uses.
+func expandEdges(
+	list *sku.HeapTransacted,
+	objectStore sku.RepoStore,
+	explorer sku.EdgeExplorer,
+) (allEdges sku.Edges, err error) {
+	if explorer == nil {
+		return allEdges, nil
+	}
+
+	seen := make(map[string]struct{})
+	seenBlobs := make(map[string]struct{})
+
+	for object := range list.All() {
+		seen[object.GetObjectId().String()] = struct{}{}
+	}
+
+	for range maxEdgeExpansionDepth {
+		var pendingIds []ids.ObjectId
+
+		for object := range list.All() {
+			edges, exploreErr := explorer.ExploreEdges(object)
+			if exploreErr != nil {
+				return allEdges, errors.Wrap(exploreErr)
+			}
+
+			for _, oid := range edges.Objects {
+				key := oid.String()
+				if _, ok := seen[key]; !ok {
+					seen[key] = struct{}{}
+					pendingIds = append(pendingIds, oid)
+				}
+			}
+
+			for _, blobId := range edges.Blobs {
+				key := blobId.String()
+				if _, ok := seenBlobs[key]; !ok {
+					seenBlobs[key] = struct{}{}
+					allEdges.Blobs = append(allEdges.Blobs, blobId)
+				}
+			}
+
+			allEdges.Skipped = append(allEdges.Skipped, edges.Skipped...)
+		}
+
+		if len(pendingIds) == 0 {
+			break
+		}
+
+		for i := range pendingIds {
+			fetched, repool := sku.GetTransactedPool().GetWithRepool() //repool:suppress ownership transfer to list
+
+			if err = objectStore.ReadOneInto(&pendingIds[i], fetched); err != nil {
+				repool()
+
+				if errors.IsErrNotFound(err) {
+					err = nil
+					continue
+				}
+
+				return allEdges, errors.Wrap(err)
+			}
+
+			allEdges.Objects = append(allEdges.Objects, pendingIds[i])
+
+			if err = list.Add(fetched); err != nil {
+				repool()
+				return allEdges, errors.Wrap(err)
+			}
+		}
+	}
+
+	return allEdges, nil
+}

--- a/go/internal/sierra/remote_proto/frame.go
+++ b/go/internal/sierra/remote_proto/frame.go
@@ -1,0 +1,93 @@
+package remote_proto
+
+import (
+	"encoding/binary"
+	"io"
+
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/errors"
+)
+
+// frameHeaderLen is the fixed framing overhead: one kind byte plus a
+// big-endian uint32 length.
+const frameHeaderLen = 1 + 4
+
+// writeFrame writes one frame — kind byte, big-endian uint32 length, then
+// payload — to w.
+func writeFrame(w io.Writer, kind frameKind, payload []byte) (err error) {
+	var header [frameHeaderLen]byte
+	header[0] = byte(kind)
+	binary.BigEndian.PutUint32(header[1:], uint32(len(payload)))
+
+	if _, err = w.Write(header[:]); err != nil {
+		err = errors.Wrapf(err, "writing frame header")
+		return err
+	}
+
+	if _, err = w.Write(payload); err != nil {
+		err = errors.Wrapf(err, "writing frame payload")
+		return err
+	}
+
+	return err
+}
+
+// readFrameHeader reads a frame's kind and payload length. The caller then
+// reads exactly length bytes of payload (directly, for streaming, or via
+// readFramePayload for buffered control frames).
+func readFrameHeader(r io.Reader) (kind frameKind, length uint32, err error) {
+	var header [frameHeaderLen]byte
+
+	if _, err = io.ReadFull(r, header[:]); err != nil {
+		// EOF here is the ordinary "peer closed the stream" signal; the
+		// caller distinguishes it from a truncated payload.
+		if !errors.IsEOF(err) {
+			err = errors.Wrapf(err, "reading frame header")
+		}
+		return kind, length, err
+	}
+
+	kind = frameKind(header[0])
+	length = binary.BigEndian.Uint32(header[1:])
+
+	return kind, length, err
+}
+
+// readFramePayload reads exactly length bytes of a control or objects frame
+// payload, rejecting an oversized length before allocating.
+func readFramePayload(r io.Reader, length uint32) (payload []byte, err error) {
+	if length > maxControlFrameLen {
+		err = errors.Errorf(
+			"frame length %d exceeds maximum %d",
+			length,
+			maxControlFrameLen,
+		)
+		return payload, err
+	}
+
+	payload = make([]byte, length)
+
+	if _, err = io.ReadFull(r, payload); err != nil {
+		err = errors.Wrapf(err, "reading frame payload (%d bytes)", length)
+		return payload, err
+	}
+
+	return payload, err
+}
+
+// writeControlFrame encodes a control message and writes it as a single
+// control frame.
+func writeControlFrame(w io.Writer, typeString string, msg control) (err error) {
+	var payload []byte
+
+	if payload, err = encodeControl(typeString, msg); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	if err = writeFrame(w, frameKindControl, payload); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	return err
+}

--- a/go/internal/sierra/remote_proto/handshake.go
+++ b/go/internal/sierra/remote_proto/handshake.go
@@ -1,0 +1,214 @@
+package remote_proto
+
+import (
+	"bytes"
+
+	mad_domain_interfaces "github.com/amarbel-llc/madder/go/pkgs/domain_interfaces"
+	"github.com/amarbel-llc/madder/go/pkgs/markl"
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/errors"
+)
+
+// keys is the keypair a peer uses for the per-session challenge/response.
+// It is decoupled from *local_working_copy.Repo (the production source) so
+// the handshake can be unit-tested with generated keys over net.Pipe.
+type keys struct {
+	private mad_domain_interfaces.MarklId
+	public  mad_domain_interfaces.MarklId
+}
+
+func (k keys) publicString() string {
+	if k.public == nil || k.public.IsNull() {
+		return ""
+	}
+
+	return k.public.String()
+}
+
+// clientHandshake sends the client capabilities, then reads and verifies the
+// server capabilities. It returns the server's capabilities (whose Nonce the
+// caller signs into its want frame) so mutual attestation completes within
+// the want exchange. The server MUST attest (sign the client's nonce);
+// pinnedPublicKey, when non-nil, additionally pins the server identity.
+func clientHandshake(
+	s *session,
+	self keys,
+	listType string,
+	pinnedPublicKey mad_domain_interfaces.MarklId,
+) (serverCaps control, clientNonce string, err error) {
+	if clientNonce, err = generateNonce(); err != nil {
+		err = errors.Wrap(err)
+		return serverCaps, clientNonce, err
+	}
+
+	if err = s.writeControl(TypeCapabilities, control{
+		ProtocolVersion:   ProtocolVersion,
+		Role:              RoleClient,
+		InventoryListType: listType,
+		ExpandEdges:       true,
+		PublicKey:         self.publicString(),
+		Nonce:             clientNonce,
+	}); err != nil {
+		err = errors.Wrap(err)
+		return serverCaps, clientNonce, err
+	}
+
+	if serverCaps, err = s.readControlExpecting(TypeCapabilities); err != nil {
+		err = errors.Wrap(err)
+		return serverCaps, clientNonce, err
+	}
+
+	if serverCaps.ProtocolVersion != ProtocolVersion {
+		err = errors.Errorf(
+			"unsupported remote protocol version %d (need %d)",
+			serverCaps.ProtocolVersion,
+			ProtocolVersion,
+		)
+		return serverCaps, clientNonce, err
+	}
+
+	if pinnedPublicKey != nil && !pinnedPublicKey.IsNull() {
+		if err = assertPublicKeyMatches(
+			pinnedPublicKey,
+			serverCaps.PublicKey,
+		); err != nil {
+			err = errors.Wrap(err)
+			return serverCaps, clientNonce, err
+		}
+	}
+
+	// The server must always attest by signing the client's nonce, exactly
+	// as remote_http requires a signed challenge response.
+	if err = verifyNonceSignature(
+		serverCaps.PublicKey,
+		clientNonce,
+		serverCaps.Signature,
+	); err != nil {
+		err = errors.Wrapf(err, "verifying server attestation")
+		return serverCaps, clientNonce, err
+	}
+
+	return serverCaps, clientNonce, err
+}
+
+// signWant produces the client's want frame, signing the server's nonce so
+// the server can attest the client (required for a push, optional for a
+// public fetch).
+func signWant(
+	self keys,
+	serverNonce string,
+	want control,
+) (signed control, err error) {
+	signed = want
+	signed.PublicKey = self.publicString()
+
+	if self.private != nil && !self.private.IsNull() && serverNonce != "" {
+		if signed.Signature, err = signNonce(self.private, serverNonce); err != nil {
+			err = errors.Wrap(err)
+			return signed, err
+		}
+	}
+
+	return signed, err
+}
+
+// serverHandshake reads the client capabilities, sends the server
+// capabilities (signing the client's nonce), then reads the want and — unless
+// the connection is a public read — verifies the client's attestation over
+// the server's nonce.
+func serverHandshake(
+	s *session,
+	self keys,
+	listType string,
+	public bool,
+) (clientCaps, want control, err error) {
+	if clientCaps, err = s.readControlExpecting(TypeCapabilities); err != nil {
+		err = errors.Wrap(err)
+		return clientCaps, want, err
+	}
+
+	if clientCaps.ProtocolVersion != ProtocolVersion {
+		err = errors.Errorf(
+			"unsupported client protocol version %d (need %d)",
+			clientCaps.ProtocolVersion,
+			ProtocolVersion,
+		)
+		s.writeError(err.Error(), 400)
+		return clientCaps, want, err
+	}
+
+	var serverNonce string
+
+	if serverNonce, err = generateNonce(); err != nil {
+		err = errors.Wrap(err)
+		return clientCaps, want, err
+	}
+
+	var serverSignature string
+
+	if clientCaps.Nonce != "" && self.private != nil && !self.private.IsNull() {
+		if serverSignature, err = signNonce(self.private, clientCaps.Nonce); err != nil {
+			err = errors.Wrap(err)
+			return clientCaps, want, err
+		}
+	}
+
+	if err = s.writeControl(TypeCapabilities, control{
+		ProtocolVersion:   ProtocolVersion,
+		Role:              RoleServer,
+		InventoryListType: listType,
+		ExpandEdges:       true,
+		Public:            public,
+		PublicKey:         self.publicString(),
+		Nonce:             serverNonce,
+		Signature:         serverSignature,
+	}); err != nil {
+		err = errors.Wrap(err)
+		return clientCaps, want, err
+	}
+
+	if want, err = s.readControlExpecting(TypeWant); err != nil {
+		err = errors.Wrap(err)
+		return clientCaps, want, err
+	}
+
+	// A push (the client writes to us) always requires client attestation. A
+	// public fetch may waive it, mirroring remote_http's Public read mode.
+	requireClientAuth := want.Direction == DirectionPush || !public
+
+	if requireClientAuth {
+		if err = verifyNonceSignature(
+			clientCaps.PublicKey,
+			serverNonce,
+			want.Signature,
+		); err != nil {
+			err = errors.Wrapf(err, "verifying client attestation")
+			s.writeError(err.Error(), 401)
+			return clientCaps, want, err
+		}
+	}
+
+	return clientCaps, want, err
+}
+
+func assertPublicKeyMatches(
+	expected mad_domain_interfaces.MarklId,
+	actualString string,
+) (err error) {
+	var actual markl.Id
+
+	if err = actual.Set(actualString); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	if !bytes.Equal(expected.GetBytes(), actual.GetBytes()) {
+		err = errors.Errorf(
+			"remote public key mismatch: expected %q, got %q",
+			expected,
+			actualString,
+		)
+		return err
+	}
+
+	return err
+}

--- a/go/internal/sierra/remote_proto/handshake.go
+++ b/go/internal/sierra/remote_proto/handshake.go
@@ -45,6 +45,7 @@ func clientHandshake(
 		Role:              RoleClient,
 		InventoryListType: listType,
 		ExpandEdges:       true,
+		Compression:       supportedCompression,
 		PublicKey:         self.publicString(),
 		Nonce:             clientNonce,
 	}); err != nil {
@@ -157,6 +158,7 @@ func serverHandshake(
 		Role:              RoleServer,
 		InventoryListType: listType,
 		ExpandEdges:       true,
+		Compression:       supportedCompression,
 		Public:            public,
 		PublicKey:         self.publicString(),
 		Nonce:             serverNonce,
@@ -188,6 +190,16 @@ func serverHandshake(
 	}
 
 	return clientCaps, want, err
+}
+
+// negotiateCompression picks the blob compression a sender uses: the
+// advertised algorithm when the peer also supports it, otherwise none.
+func negotiateCompression(peerCompression string) string {
+	if peerCompression == supportedCompression {
+		return supportedCompression
+	}
+
+	return CompressionNone
 }
 
 func assertPublicKeyMatches(

--- a/go/internal/sierra/remote_proto/handshake_test.go
+++ b/go/internal/sierra/remote_proto/handshake_test.go
@@ -1,0 +1,188 @@
+package remote_proto
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/amarbel-llc/madder/go/pkgs/markl"
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/ui"
+	"github.com/coder/websocket"
+)
+
+const testListType = "inventory_list-v2"
+
+func makeTestKeys(t *testing.T) keys {
+	t.Helper()
+
+	_, edPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey: %v", err)
+	}
+	edPub := edPriv.Public().(ed25519.PublicKey)
+
+	priv := &markl.Id{}
+	if err := priv.SetPurposeId(markl.PurposeRepoPrivateKeyV1); err != nil {
+		t.Fatalf("priv.SetPurposeId: %v", err)
+	}
+	if err := priv.SetMarklId(markl.FormatIdEd25519Sec, []byte(edPriv)); err != nil {
+		t.Fatalf("priv.SetMarklId: %v", err)
+	}
+
+	pub := &markl.Id{}
+	if err := pub.SetPurposeId(markl.PurposeRepoPubKeyV1); err != nil {
+		t.Fatalf("pub.SetPurposeId: %v", err)
+	}
+	if err := pub.SetMarklId(markl.FormatIdEd25519Pub, []byte(edPub)); err != nil {
+		t.Fatalf("pub.SetMarklId: %v", err)
+	}
+
+	return keys{private: priv, public: pub}
+}
+
+// TestHandshakeMutualAttestation runs a full client/server handshake over an
+// in-memory pipe with generated keys and asserts mutual attestation succeeds
+// and the want is delivered intact.
+func TestHandshakeMutualAttestation(t1 *testing.T) {
+	t := ui.MakeT(t1)
+
+	clientConn, serverConn := net.Pipe()
+
+	serverKeys := makeTestKeys(t.T)
+	clientKeys := makeTestKeys(t.T)
+
+	type serverResult struct {
+		want control
+		err  error
+	}
+
+	results := make(chan serverResult, 1)
+
+	go func() {
+		s := makeSession(serverConn)
+		_, want, err := serverHandshake(s, serverKeys, testListType, false)
+		results <- serverResult{want: want, err: err}
+	}()
+
+	s := makeSession(clientConn)
+
+	serverCaps, _, err := clientHandshake(s, clientKeys, testListType, serverKeys.public)
+	t.AssertNoError(err)
+	t.AssertEqual(testListType, serverCaps.InventoryListType)
+	t.AssertEqual(RoleServer, serverCaps.Role)
+
+	want, err := signWant(clientKeys, serverCaps.Nonce, control{
+		Direction: DirectionFetch,
+		Query:     ":z",
+	})
+	t.AssertNoError(err)
+	t.AssertNoError(s.writeControl(TypeWant, want))
+
+	got := <-results
+	t.AssertNoError(got.err)
+	t.AssertEqual(DirectionFetch, got.want.Direction)
+	t.AssertEqual(":z", got.want.Query)
+}
+
+// TestHandshakePinnedKeyMismatch asserts a client that pins a different
+// server key rejects the connection.
+func TestHandshakePinnedKeyMismatch(t1 *testing.T) {
+	t := ui.MakeT(t1)
+
+	clientConn, serverConn := net.Pipe()
+
+	serverKeys := makeTestKeys(t.T)
+	clientKeys := makeTestKeys(t.T)
+	otherKeys := makeTestKeys(t.T)
+
+	go func() {
+		s := makeSession(serverConn)
+		_, _, _ = serverHandshake(s, serverKeys, testListType, false)
+		_ = serverConn.Close()
+	}()
+
+	s := makeSession(clientConn)
+	defer func() { _ = clientConn.Close() }()
+
+	_, _, err := clientHandshake(s, clientKeys, testListType, otherKeys.public)
+	t.AssertError(err)
+	if !strings.Contains(err.Error(), "public key mismatch") {
+		t.Fatalf("expected public key mismatch, got: %v", err)
+	}
+}
+
+// TestHandshakeOverWebSocket exercises the websocket transport end to end:
+// the handshake runs over a real upgraded connection adapted via
+// websocket.NetConn, verifying framing survives message boundaries.
+func TestHandshakeOverWebSocket(t1 *testing.T) {
+	t := ui.MakeT(t1)
+
+	serverKeys := makeTestKeys(t.T)
+	clientKeys := makeTestKeys(t.T)
+
+	wantReceived := make(chan control, 1)
+	serverErr := make(chan error, 1)
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+			InsecureSkipVerify: true,
+		})
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		conn.SetReadLimit(-1)
+		defer conn.Close(websocket.StatusNormalClosure, "")
+
+		netConn := websocket.NetConn(r.Context(), conn, websocket.MessageBinary)
+		s := makeSession(netConn)
+
+		_, want, hErr := serverHandshake(s, serverKeys, testListType, true)
+		if hErr != nil {
+			serverErr <- hErr
+			return
+		}
+
+		wantReceived <- want
+		serverErr <- nil
+	}
+
+	httpServer := httptest.NewServer(http.HandlerFunc(handler))
+	defer httpServer.Close()
+
+	wsURL := WebSocketURL(httpServer.URL)
+	if !strings.HasPrefix(wsURL, "ws://") {
+		t.Fatalf("expected ws:// URL, got %q", wsURL)
+	}
+
+	ctx := context.Background()
+
+	conn, err := DialWebSocket(ctx, wsURL)
+	t.AssertNoError(err)
+
+	s := makeSession(conn)
+
+	serverCaps, _, err := clientHandshake(s, clientKeys, testListType, serverKeys.public)
+	t.AssertNoError(err)
+	t.AssertEqual(testListType, serverCaps.InventoryListType)
+
+	want, err := signWant(clientKeys, serverCaps.Nonce, control{
+		Direction: DirectionFetch,
+		Query:     ":t",
+	})
+	t.AssertNoError(err)
+	t.AssertNoError(s.writeControl(TypeWant, want))
+
+	t.AssertNoError(<-serverErr)
+
+	got := <-wantReceived
+	t.AssertEqual(DirectionFetch, got.Direction)
+	t.AssertEqual(":t", got.Query)
+
+	_ = conn.Close()
+}

--- a/go/internal/sierra/remote_proto/protocol.go
+++ b/go/internal/sierra/remote_proto/protocol.go
@@ -43,6 +43,7 @@ const PathHealthz = "/healthz"
 const (
 	TypeCapabilities = "drtp-capabilities-v1"
 	TypeWant         = "drtp-want-v1"
+	TypeManifest     = "drtp-manifest-v1"
 	TypeHave         = "drtp-have-v1"
 	TypeBlobHeader   = "drtp-blob_header-v1"
 	TypeAck          = "drtp-ack-v1"

--- a/go/internal/sierra/remote_proto/protocol.go
+++ b/go/internal/sierra/remote_proto/protocol.go
@@ -1,0 +1,91 @@
+// Package remote_proto implements the dodder remote transfer protocol
+// (drtp), specified in docs/rfcs/0004-remote-transfer-protocol.md.
+//
+// It is a hard fork of sierra/remote_http: rather than a sequence of REST
+// calls glued together by a reactive missing-blob retry loop, drtp is a
+// session protocol. One byte stream carries a whole transfer from a
+// capability handshake through a single, sender-computed object and blob
+// stream. The exchange takes its shape from git's fetch/push: capability
+// advertisement, want/have negotiation, and a batched object stream.
+//
+// Every control and payload message on the wire is a typed hyphence
+// document (RFC 0001), so the protocol inherits hyphence's type-string
+// versioning and markl-id (RFC 0002) content addressing rather than a
+// bespoke pack format. The sender computes the transfer's transitive
+// closure up front with the type system's expand-edges traversal
+// (sku.EdgeExplorer), so a fetch delivers a complete, self-consistent
+// object graph in one pass.
+//
+// The session runs over any reliable, ordered, bidirectional byte stream:
+// stdio, a unix socket, TCP, or — the motivating addition — a WebSocket
+// upgraded from HTTP (see transport_websocket.go). WebSocket support is
+// optional and negotiated.
+package remote_proto
+
+// ProtocolVersion is the drtp wire-protocol version advertised in the
+// capabilities handshake. Bumped only on an incompatible change to the
+// overall exchange shape; additive changes ride hyphence type-string
+// versioning instead (see the RFC, "Versioning and Evolution").
+const ProtocolVersion = 1
+
+// PathTransfer is the HTTP path a websocket-capable server exposes for the
+// upgrade. A client requesting websocket transport issues the upgrade here.
+const PathTransfer = "/drtp"
+
+// PathHealthz mirrors remote_http's liveness route so probes need no
+// upgrade.
+const PathHealthz = "/healthz"
+
+// Control-message type strings. Each is the hyphence type of a control
+// frame's typed document. New fields are additive (decoded leniently);
+// an incompatible change introduces a new "-vN" string and keeps the old
+// one decodable, per horizontal versioning.
+const (
+	TypeCapabilities = "drtp-capabilities-v1"
+	TypeWant         = "drtp-want-v1"
+	TypeHave         = "drtp-have-v1"
+	TypeBlobHeader   = "drtp-blob_header-v1"
+	TypeAck          = "drtp-ack-v1"
+	TypeError        = "drtp-error-v1"
+)
+
+// Transfer directions carried in a want frame. Fetch makes the server the
+// sender (pull/clone); push makes the client the sender.
+const (
+	DirectionFetch = "fetch"
+	DirectionPush  = "push"
+)
+
+// Roles advertised in a capabilities frame.
+const (
+	RoleClient = "client"
+	RoleServer = "server"
+)
+
+// Ack statuses.
+const (
+	StatusComplete = "complete"
+)
+
+// frameKind identifies how a frame's payload is interpreted. It is the
+// single leading byte of every frame (see frame.go).
+type frameKind byte
+
+const (
+	// frameKindControl payloads are a single typed hyphence control
+	// document (one of the Type* strings above).
+	frameKindControl frameKind = 0x01
+	// frameKindObjects payloads are an inventory_list hyphence stream,
+	// encoded by inventory_list_coders.Closet — the same bytes used for
+	// on-disk and HTTP object transfer.
+	frameKindObjects frameKind = 0x02
+	// frameKindBlob payloads are the raw bytes of one content-addressed
+	// blob. A blob frame is always immediately preceded by a control
+	// frame of type TypeBlobHeader announcing its markl id and length.
+	frameKindBlob frameKind = 0x03
+)
+
+// maxControlFrameLen bounds a single control or objects frame so a peer
+// cannot exhaust memory with an oversized length prefix. Blob payloads are
+// bounded by their announced header length and streamed.
+const maxControlFrameLen = 64 << 20 // 64 MiB

--- a/go/internal/sierra/remote_proto/protocol.go
+++ b/go/internal/sierra/remote_proto/protocol.go
@@ -68,6 +68,18 @@ const (
 	StatusComplete = "complete"
 )
 
+// Blob compression algorithms negotiated in capabilities and named in a
+// blob_header. CompressionNone (the empty string) is always supported;
+// CompressionZstd matches dodder's at-rest blob compression convention.
+const (
+	CompressionNone = ""
+	CompressionZstd = "zstd"
+)
+
+// supportedCompression is the algorithm this implementation advertises and
+// will use when the peer also supports it.
+const supportedCompression = CompressionZstd
+
 // frameKind identifies how a frame's payload is interpreted. It is the
 // single leading byte of every frame (see frame.go).
 type frameKind byte

--- a/go/internal/sierra/remote_proto/server.go
+++ b/go/internal/sierra/remote_proto/server.go
@@ -1,0 +1,119 @@
+package remote_proto
+
+import (
+	"io"
+
+	"code.linenisgreat.com/dodder/go/internal/foxtrot/sku"
+	"code.linenisgreat.com/dodder/go/internal/romeo/local_working_copy"
+	mad_domain_interfaces "github.com/amarbel-llc/madder/go/pkgs/domain_interfaces"
+	env_local "github.com/amarbel-llc/madder/go/pkgs/env_local"
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/errors"
+)
+
+// KeySource provides the keypair the session handshake uses to attest the
+// server (and verify the client). Lifting key access off the concrete repo
+// lets tests inject a generated keypair, exactly as remote_http does.
+type KeySource interface {
+	GetPublicKey() mad_domain_interfaces.MarklId
+	GetPrivateKey() mad_domain_interfaces.MarklId
+}
+
+// Server runs the receive/upload half of the drtp protocol over accepted
+// connections. It is the hard-fork counterpart of remote_http.Server; the
+// two coexist.
+type Server struct {
+	EnvLocal env_local.Env
+	Repo     *local_working_copy.Repo
+
+	// Public waives the client's attestation for fetches (read-only),
+	// mirroring remote_http.Server.Public. A push always requires client
+	// attestation regardless.
+	Public bool
+
+	// KeySource overrides the Repo-backed keys; nil in production.
+	KeySource KeySource
+}
+
+func (server *Server) keys() keys {
+	if server.KeySource != nil {
+		return keys{
+			private: server.KeySource.GetPrivateKey(),
+			public:  server.KeySource.GetPublicKey(),
+		}
+	}
+
+	return keys{
+		private: server.Repo.GetImmutableConfigPrivate().Blob.GetPrivateKey(),
+		public:  server.Repo.GetImmutableConfigPublic().GetPublicKey(),
+	}
+}
+
+func (server *Server) listType() string {
+	return server.Repo.GetImmutableConfigPublic().GetInventoryListTypeId()
+}
+
+// ServeConn runs a single drtp session over conn. The caller owns conn's
+// lifetime; ServeConn does not close it (the transport layer that produced
+// conn does).
+func (server *Server) ServeConn(conn io.ReadWriteCloser) (err error) {
+	if err = server.serveSession(makeSession(conn)); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	return err
+}
+
+func (server *Server) serveSession(s *session) (err error) {
+	env := server.Repo.GetEnv()
+
+	var want control
+
+	if _, want, err = serverHandshake(
+		s,
+		server.keys(),
+		server.listType(),
+		server.Public,
+	); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	switch want.Direction {
+	case DirectionFetch, "":
+		// The client fetches: the server is the sender. It computes the
+		// closure from its own store and streams it.
+		if err = sendClosure(
+			env,
+			s,
+			server.Repo,
+			server.Repo.GetEnvRepo(),
+			want,
+		); err != nil {
+			s.writeError(err.Error(), 500)
+			err = errors.Wrap(err)
+			return err
+		}
+
+	case DirectionPush:
+		// The client pushes: the server is the receiver.
+		if err = receiveClosure(
+			env,
+			s,
+			server.Repo,
+			want,
+			sku.GetStoreOptionsRemoteTransfer(),
+		); err != nil {
+			s.writeError(err.Error(), 500)
+			err = errors.Wrap(err)
+			return err
+		}
+
+	default:
+		err = errors.Errorf("unknown transfer direction %q", want.Direction)
+		s.writeError(err.Error(), 400)
+		return err
+	}
+
+	return err
+}

--- a/go/internal/sierra/remote_proto/server.go
+++ b/go/internal/sierra/remote_proto/server.go
@@ -67,9 +67,10 @@ func (server *Server) ServeConn(conn io.ReadWriteCloser) (err error) {
 func (server *Server) serveSession(s *session) (err error) {
 	env := server.Repo.GetEnv()
 
+	var clientCaps control
 	var want control
 
-	if _, want, err = serverHandshake(
+	if clientCaps, want, err = serverHandshake(
 		s,
 		server.keys(),
 		server.listType(),
@@ -82,13 +83,15 @@ func (server *Server) serveSession(s *session) (err error) {
 	switch want.Direction {
 	case DirectionFetch, "":
 		// The client fetches: the server is the sender. It computes the
-		// closure from its own store and streams it.
+		// closure from its own store and streams it, compressing blobs when
+		// the client advertised support.
 		if err = sendClosure(
 			env,
 			s,
 			server.Repo,
 			server.Repo.GetEnvRepo(),
 			want,
+			negotiateCompression(clientCaps.Compression),
 		); err != nil {
 			s.writeError(err.Error(), 500)
 			err = errors.Wrap(err)

--- a/go/internal/sierra/remote_proto/session.go
+++ b/go/internal/sierra/remote_proto/session.go
@@ -1,0 +1,167 @@
+package remote_proto
+
+import (
+	"bufio"
+	"io"
+
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/errors"
+)
+
+// session wraps the byte stream of one transfer with buffered framing. It
+// is transport-agnostic: the underlying io.ReadWriteCloser may be a stdio
+// pipe, a unix/TCP net.Conn, a websocket adapted via websocket.NetConn, or
+// an in-memory net.Pipe (used by the unit tests).
+type session struct {
+	conn   io.ReadWriteCloser
+	reader *bufio.Reader
+	writer *bufio.Writer
+}
+
+func makeSession(conn io.ReadWriteCloser) *session {
+	return &session{
+		conn:   conn,
+		reader: bufio.NewReader(conn),
+		writer: bufio.NewWriter(conn),
+	}
+}
+
+func (s *session) Close() error {
+	return s.conn.Close()
+}
+
+// writeControl writes a control message as one control frame and flushes.
+func (s *session) writeControl(typeString string, msg control) (err error) {
+	if err = writeControlFrame(s.writer, typeString, msg); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	if err = s.writer.Flush(); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	return err
+}
+
+// writeObjects writes an encoded inventory_list payload as one objects
+// frame and flushes.
+func (s *session) writeObjects(payload []byte) (err error) {
+	if err = writeFrame(s.writer, frameKindObjects, payload); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	if err = s.writer.Flush(); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	return err
+}
+
+// writeBlob writes a blob_header control frame followed by the blob's bytes
+// as one blob frame, then flushes.
+func (s *session) writeBlob(blobIdString string, payload []byte) (err error) {
+	if err = writeControlFrame(s.writer, TypeBlobHeader, control{
+		BlobId:     blobIdString,
+		BlobLength: int64(len(payload)),
+	}); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	if err = writeFrame(s.writer, frameKindBlob, payload); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	if err = s.writer.Flush(); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	return err
+}
+
+// readControl reads the next frame, which MUST be a control frame, and
+// decodes it. Returns the type string (with leading "!") and the envelope.
+func (s *session) readControl() (typeString string, msg control, err error) {
+	kind, length, err := readFrameHeader(s.reader)
+	if err != nil {
+		// Propagate EOF unwrapped so callers can detect a clean close.
+		if errors.IsEOF(err) {
+			return typeString, msg, io.EOF
+		}
+		err = errors.Wrap(err)
+		return typeString, msg, err
+	}
+
+	if kind != frameKindControl {
+		err = errors.Errorf("expected control frame, got kind %d", kind)
+		return typeString, msg, err
+	}
+
+	var payload []byte
+
+	if payload, err = readFramePayload(s.reader, length); err != nil {
+		err = errors.Wrap(err)
+		return typeString, msg, err
+	}
+
+	if typeString, msg, err = decodeControl(payload); err != nil {
+		err = errors.Wrap(err)
+		return typeString, msg, err
+	}
+
+	return typeString, msg, err
+}
+
+// readControlExpecting reads a control frame and asserts its type. A
+// TypeError frame is surfaced as the remote's error regardless of the
+// expected type.
+func (s *session) readControlExpecting(
+	expectedTypeString string,
+) (msg control, err error) {
+	var typeString string
+
+	if typeString, msg, err = s.readControl(); err != nil {
+		// Never wrap a bare io.EOF (the errors package panics on it);
+		// surface a descriptive terminal error instead.
+		if errors.IsEOF(err) {
+			err = errors.Errorf(
+				"connection closed before %q frame",
+				expectedTypeString,
+			)
+			return msg, err
+		}
+
+		err = errors.Wrap(err)
+		return msg, err
+	}
+
+	if typeString == "!"+TypeError {
+		err = errors.Errorf("remote error: %s", msg.Message)
+		return msg, err
+	}
+
+	if typeString != "!"+expectedTypeString {
+		err = errors.Errorf(
+			"expected %q frame, got %q",
+			expectedTypeString,
+			typeString,
+		)
+		return msg, err
+	}
+
+	return msg, err
+}
+
+// writeError writes a terminal error control frame. The write error (if
+// any) is best-effort; the caller's original error is what matters.
+func (s *session) writeError(message string, statusCode int) {
+	_ = s.writeControl(TypeError, control{
+		Message:    message,
+		StatusCode: statusCode,
+	})
+}

--- a/go/internal/sierra/remote_proto/session.go
+++ b/go/internal/sierra/remote_proto/session.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"io"
 
+	"github.com/DataDog/zstd"
 	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/errors"
 )
 
@@ -64,35 +65,43 @@ func (s *session) writeObjects(payload []byte) (err error) {
 // constant memory rather than being buffered whole.
 const blobChunkSize = 64 * 1024
 
-// writeBlob writes a blob_header control frame, then streams the blob's bytes
-// as a sequence of blob frames, terminated by a zero-length blob frame, then
-// flushes. The blob is never held in memory in full.
-func (s *session) writeBlob(blobIdString string, reader io.Reader) (err error) {
+// writeBlob writes a blob_header control frame (naming the blob and, when
+// compressed, the algorithm), streams the blob's bytes — optionally through a
+// zstd encoder — as a sequence of blob frames terminated by a zero-length
+// frame, then flushes. The blob is never held in memory in full.
+func (s *session) writeBlob(
+	blobIdString string,
+	reader io.Reader,
+	compression string,
+) (err error) {
 	if err = writeControlFrame(s.writer, TypeBlobHeader, control{
-		BlobId: blobIdString,
+		BlobId:      blobIdString,
+		Compression: compression,
 	}); err != nil {
 		err = errors.Wrap(err)
 		return err
 	}
 
-	buffer := make([]byte, blobChunkSize)
+	frameWriter := &blobFrameWriter{session: s}
 
-	for {
-		n, readErr := reader.Read(buffer)
+	switch compression {
+	case CompressionZstd:
+		encoder := zstd.NewWriter(frameWriter)
 
-		if n > 0 {
-			if err = writeFrame(s.writer, frameKindBlob, buffer[:n]); err != nil {
-				err = errors.Wrap(err)
-				return err
-			}
+		if _, err = io.Copy(encoder, reader); err != nil {
+			_ = encoder.Close()
+			err = errors.Wrapf(err, "compressing blob %s", blobIdString)
+			return err
 		}
 
-		if readErr != nil {
-			if errors.IsEOF(readErr) {
-				break
-			}
+		if err = encoder.Close(); err != nil {
+			err = errors.Wrapf(err, "finishing blob %s compression", blobIdString)
+			return err
+		}
 
-			err = errors.Wrapf(readErr, "reading blob %s", blobIdString)
+	default:
+		if _, err = io.Copy(frameWriter, reader); err != nil {
+			err = errors.Wrapf(err, "reading blob %s", blobIdString)
 			return err
 		}
 	}
@@ -109,6 +118,84 @@ func (s *session) writeBlob(blobIdString string, reader io.Reader) (err error) {
 	}
 
 	return err
+}
+
+// blobFrameWriter chops every Write into blob frames no larger than
+// blobChunkSize. It is the sink for the raw or zstd-compressed blob byte
+// stream.
+type blobFrameWriter struct {
+	session *session
+}
+
+func (w *blobFrameWriter) Write(p []byte) (n int, err error) {
+	for len(p) > 0 {
+		chunk := p
+		if len(chunk) > blobChunkSize {
+			chunk = chunk[:blobChunkSize]
+		}
+
+		if err = writeFrame(w.session.writer, frameKindBlob, chunk); err != nil {
+			err = errors.Wrap(err)
+			return n, err
+		}
+
+		n += len(chunk)
+		p = p[len(chunk):]
+	}
+
+	return n, err
+}
+
+// blobFrameReader presents the blob frames between a blob_header and the
+// zero-length terminator as a single io.Reader, so the receiver can stream
+// them straight into the blob writer (or through a zstd decoder).
+type blobFrameReader struct {
+	session   *session
+	remaining int
+	done      bool
+}
+
+func (r *blobFrameReader) Read(p []byte) (n int, err error) {
+	if r.done {
+		return 0, io.EOF
+	}
+
+	if r.remaining == 0 {
+		kind, length, frameErr := readFrameHeader(r.session.reader)
+		if frameErr != nil {
+			if errors.IsEOF(frameErr) {
+				return 0, io.EOF
+			}
+
+			return 0, errors.Wrap(frameErr)
+		}
+
+		if kind != frameKindBlob {
+			return 0, errors.Errorf(
+				"expected blob frame, got kind %d",
+				kind,
+			)
+		}
+
+		if length == 0 {
+			r.done = true
+			return 0, io.EOF
+		}
+
+		r.remaining = int(length)
+	}
+
+	toRead := len(p)
+	if toRead > r.remaining {
+		toRead = r.remaining
+	}
+
+	n, err = r.session.reader.Read(p[:toRead])
+	r.remaining -= n
+
+	// Read errors other than a clean intra-frame boundary are real; a
+	// truncated frame surfaces here.
+	return n, err
 }
 
 // readControl reads the next frame, which MUST be a control frame, and

--- a/go/internal/sierra/remote_proto/session.go
+++ b/go/internal/sierra/remote_proto/session.go
@@ -60,18 +60,45 @@ func (s *session) writeObjects(payload []byte) (err error) {
 	return err
 }
 
-// writeBlob writes a blob_header control frame followed by the blob's bytes
-// as one blob frame, then flushes.
-func (s *session) writeBlob(blobIdString string, payload []byte) (err error) {
+// blobChunkSize bounds each blob frame so a blob of any size streams with
+// constant memory rather than being buffered whole.
+const blobChunkSize = 64 * 1024
+
+// writeBlob writes a blob_header control frame, then streams the blob's bytes
+// as a sequence of blob frames, terminated by a zero-length blob frame, then
+// flushes. The blob is never held in memory in full.
+func (s *session) writeBlob(blobIdString string, reader io.Reader) (err error) {
 	if err = writeControlFrame(s.writer, TypeBlobHeader, control{
-		BlobId:     blobIdString,
-		BlobLength: int64(len(payload)),
+		BlobId: blobIdString,
 	}); err != nil {
 		err = errors.Wrap(err)
 		return err
 	}
 
-	if err = writeFrame(s.writer, frameKindBlob, payload); err != nil {
+	buffer := make([]byte, blobChunkSize)
+
+	for {
+		n, readErr := reader.Read(buffer)
+
+		if n > 0 {
+			if err = writeFrame(s.writer, frameKindBlob, buffer[:n]); err != nil {
+				err = errors.Wrap(err)
+				return err
+			}
+		}
+
+		if readErr != nil {
+			if errors.IsEOF(readErr) {
+				break
+			}
+
+			err = errors.Wrapf(readErr, "reading blob %s", blobIdString)
+			return err
+		}
+	}
+
+	// Zero-length terminator frame marks the end of the blob.
+	if err = writeFrame(s.writer, frameKindBlob, nil); err != nil {
 		err = errors.Wrap(err)
 		return err
 	}

--- a/go/internal/sierra/remote_proto/transfer.go
+++ b/go/internal/sierra/remote_proto/transfer.go
@@ -75,11 +75,37 @@ func sendClosure(
 		return err
 	}
 
+	// Have-negotiation: announce every blob in the closure the sender holds,
+	// learn which the receiver already has, and stream only the rest. The
+	// manifest/have exchange always happens (with an empty manifest when
+	// blobs are excluded) so the receiver's read stays in lockstep.
+	var manifest []string
+
 	if !want.ExcludeBlobs {
-		if err = sendBlobs(env, s, src.GetBlobStore(), list, edges); err != nil {
-			err = errors.Wrap(err)
-			return err
-		}
+		manifest = gatherBlobDigests(src.GetBlobStore(), list, edges)
+	}
+
+	if err = s.writeControl(TypeManifest, control{Blobs: manifest}); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	var have control
+
+	if have, err = s.readControlExpecting(TypeHave); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	if err = sendBlobs(
+		env,
+		s,
+		src.GetBlobStore(),
+		manifest,
+		have.HaveBlobs,
+	); err != nil {
+		err = errors.Wrap(err)
+		return err
 	}
 
 	if err = sendObjects(env, s, src, list); err != nil {
@@ -95,79 +121,117 @@ func sendClosure(
 	return err
 }
 
-// sendBlobs streams every blob in the closure: each object's own blob plus
-// every blob reference discovered by expand-edges, deduplicated. v1 sends
-// the whole closure rather than negotiating haves; the receiver's
-// content-addressed store deduplicates blobs it already holds.
-func sendBlobs(
-	env env_ui.Env,
-	s *session,
+// gatherBlobDigests collects, deduplicated, every blob digest in the
+// closure that the sender actually holds: each object's own blob plus every
+// blob reference discovered by expand-edges. Only locally-present blobs are
+// advertised, so the receiver never expects a blob the sender cannot send.
+func gatherBlobDigests(
 	blobStore blob_stores.BlobStoreInitialized,
 	list *sku.HeapTransacted,
 	edges sku.Edges,
-) (err error) {
+) (digests []string) {
 	seen := make(map[string]struct{})
 
-	send := func(digest mad_domain_interfaces.MarklId) (err error) {
+	add := func(digest mad_domain_interfaces.MarklId) {
 		if digest == nil || digest.IsNull() {
-			return err
+			return
 		}
 
 		key := digest.String()
 
 		if _, ok := seen[key]; ok {
-			return err
+			return
 		}
 
 		seen[key] = struct{}{}
 
-		var reader mad_domain_interfaces.BlobReader
-
-		if reader, err = blobStore.MakeBlobReader(digest); err != nil {
-			// A blob that is referenced but absent locally is skipped
-			// rather than failing the whole transfer, matching
-			// CopyBlobIfNecessary's tolerance on the local pull path.
-			if mad_blob_io.IsErrBlobMissing(err) {
-				return nil
-			}
-
-			err = errors.Wrapf(err, "opening blob %s", key)
-			return err
+		if !blobStore.HasBlob(digest) {
+			return
 		}
 
-		defer errors.DeferredCloser(&err, reader)
-
-		var data []byte
-
-		if data, err = io.ReadAll(reader); err != nil {
-			err = errors.Wrapf(err, "reading blob %s", key)
-			return err
-		}
-
-		if err = s.writeBlob(key, data); err != nil {
-			err = errors.Wrap(err)
-			return err
-		}
-
-		return err
+		digests = append(digests, key)
 	}
 
 	for object := range list.All() {
+		add(object.GetBlobDigest())
+	}
+
+	for i := range edges.Blobs {
+		add(&edges.Blobs[i])
+	}
+
+	return digests
+}
+
+// sendBlobs streams each manifested blob the receiver does not already hold
+// (per the have list). The receiver's content-addressed store still
+// deduplicates, but skipping known blobs here avoids the bandwidth.
+func sendBlobs(
+	env env_ui.Env,
+	s *session,
+	blobStore blob_stores.BlobStoreInitialized,
+	manifest []string,
+	haveBlobs []string,
+) (err error) {
+	have := make(map[string]struct{}, len(haveBlobs))
+
+	for _, key := range haveBlobs {
+		have[key] = struct{}{}
+	}
+
+	for _, key := range manifest {
 		errors.ContextContinueOrPanic(env)
 
-		if err = send(object.GetBlobDigest()); err != nil {
+		if _, ok := have[key]; ok {
+			continue
+		}
+
+		if err = sendOneBlob(s, blobStore, key); err != nil {
 			err = errors.Wrap(err)
 			return err
 		}
 	}
 
-	for i := range edges.Blobs {
-		errors.ContextContinueOrPanic(env)
+	return err
+}
 
-		if err = send(&edges.Blobs[i]); err != nil {
-			err = errors.Wrap(err)
-			return err
+func sendOneBlob(
+	s *session,
+	blobStore blob_stores.BlobStoreInitialized,
+	key string,
+) (err error) {
+	var digest markl.Id
+
+	if err = digest.Set(key); err != nil {
+		err = errors.Wrapf(err, "blob digest %q", key)
+		return err
+	}
+
+	var reader mad_domain_interfaces.BlobReader
+
+	if reader, err = blobStore.MakeBlobReader(&digest); err != nil {
+		// A blob that vanished between manifest and stream is skipped
+		// rather than failing the whole transfer.
+		if mad_blob_io.IsErrBlobMissing(err) {
+			return nil
 		}
+
+		err = errors.Wrapf(err, "opening blob %s", key)
+		return err
+	}
+
+	defer errors.DeferredCloser(&err, reader)
+
+	var data []byte
+
+	if data, err = io.ReadAll(reader); err != nil {
+		err = errors.Wrapf(err, "reading blob %s", key)
+		return err
+	}
+
+	if err = s.writeBlob(key, data); err != nil {
+		err = errors.Wrap(err)
+		return err
 	}
 
 	return err
@@ -217,9 +281,11 @@ func sendObjects(
 }
 
 // receiveClosure is the receiver half of a transfer (the client for fetch,
-// the server for push). It reads frames until a completion ack: blob frames
-// are written to the local store (and digest-verified), the objects frame is
-// imported through the ordinary importer.
+// the server for push). It first answers the sender's blob manifest with the
+// subset it already holds (have-negotiation), then reads frames until a
+// completion ack: blob frames are written to the local store (and
+// digest-verified), the objects frame is imported through the ordinary
+// importer.
 func receiveClosure(
 	env env_ui.Env,
 	s *session,
@@ -228,6 +294,11 @@ func receiveClosure(
 	storeOptions sku.StoreOptions,
 ) (err error) {
 	blobStore := dst.GetBlobStore()
+
+	if err = negotiateHave(s, blobStore); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
 
 	importerOptions := repo.ImporterOptions{
 		CheckedOutPrinter:   dst.PrinterCheckedOutConflictsForRemoteTransfers(),
@@ -308,6 +379,45 @@ func receiveClosure(
 			return err
 		}
 	}
+}
+
+// negotiateHave reads the sender's blob manifest and replies with the subset
+// of those digests the local store already holds, so the sender can skip
+// streaming them.
+func negotiateHave(
+	s *session,
+	blobStore blob_stores.BlobStoreInitialized,
+) (err error) {
+	var manifest control
+
+	if manifest, err = s.readControlExpecting(TypeManifest); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	var have []string
+
+	for _, key := range manifest.Blobs {
+		var digest markl.Id
+
+		if setErr := digest.Set(key); setErr != nil {
+			// An unparseable digest is simply not claimed as held; the
+			// sender will stream it and the receive-side verify catches a
+			// genuine problem.
+			continue
+		}
+
+		if blobStore.HasBlob(&digest) {
+			have = append(have, key)
+		}
+	}
+
+	if err = s.writeControl(TypeHave, control{HaveBlobs: have}); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	return err
 }
 
 // recvBlob reads the blob frame announced by a blob_header and writes it to

--- a/go/internal/sierra/remote_proto/transfer.go
+++ b/go/internal/sierra/remote_proto/transfer.go
@@ -12,6 +12,7 @@ import (
 	"code.linenisgreat.com/dodder/go/internal/papa/repo"
 	"code.linenisgreat.com/dodder/go/internal/romeo/local_working_copy"
 	"code.linenisgreat.com/dodder/go/lib/alfa/quiter"
+	"github.com/DataDog/zstd"
 	mad_blob_io "github.com/amarbel-llc/madder/go/pkgs/blob_io"
 	"github.com/amarbel-llc/madder/go/pkgs/blob_stores"
 	mad_domain_interfaces "github.com/amarbel-llc/madder/go/pkgs/domain_interfaces"
@@ -32,6 +33,7 @@ func sendClosure(
 	src repo.Repo,
 	envAdder interfaces.EnvVarsAdder,
 	want control,
+	compression string,
 ) (err error) {
 	var queryGroup *queries.Query
 
@@ -101,6 +103,7 @@ func sendClosure(
 		src.GetBlobStore(),
 		manifest,
 		have.HaveBlobs,
+		compression,
 	); err != nil {
 		err = errors.Wrap(err)
 		return err
@@ -170,6 +173,7 @@ func sendBlobs(
 	blobStore blob_stores.BlobStoreInitialized,
 	manifest []string,
 	haveBlobs []string,
+	compression string,
 ) (err error) {
 	have := make(map[string]struct{}, len(haveBlobs))
 
@@ -184,7 +188,7 @@ func sendBlobs(
 			continue
 		}
 
-		if err = sendOneBlob(s, blobStore, key); err != nil {
+		if err = sendOneBlob(s, blobStore, key, compression); err != nil {
 			err = errors.Wrap(err)
 			return err
 		}
@@ -197,6 +201,7 @@ func sendOneBlob(
 	s *session,
 	blobStore blob_stores.BlobStoreInitialized,
 	key string,
+	compression string,
 ) (err error) {
 	var digest markl.Id
 
@@ -221,8 +226,8 @@ func sendOneBlob(
 	defer errors.DeferredCloser(&err, reader)
 
 	// Stream the blob straight from the store to the wire; writeBlob chunks
-	// it so nothing is buffered whole.
-	if err = s.writeBlob(key, reader); err != nil {
+	// (and optionally compresses) it so nothing is buffered whole.
+	if err = s.writeBlob(key, reader, compression); err != nil {
 		err = errors.Wrap(err)
 		return err
 	}
@@ -335,7 +340,7 @@ func receiveClosure(
 
 			switch typeString {
 			case "!" + TypeBlobHeader:
-				if err = recvBlob(env, s, blobStore, msg); err != nil {
+				if err = recvBlob(s, blobStore, msg); err != nil {
 					err = errors.Wrap(err)
 					return err
 				}
@@ -414,10 +419,11 @@ func negotiateHave(
 }
 
 // recvBlob streams the blob announced by a blob_header into the local store —
-// a sequence of blob frames terminated by a zero-length frame — and verifies
-// the computed content digest against the header. Nothing is buffered whole.
+// a sequence of blob frames terminated by a zero-length frame, optionally
+// zstd-compressed — and verifies the computed content digest against the
+// header. The digest is computed over the decompressed bytes, so compression
+// is transparent to content addressing. Nothing is buffered whole.
 func recvBlob(
-	env env_ui.Env,
 	s *session,
 	blobStore blob_stores.BlobStoreInitialized,
 	header control,
@@ -429,7 +435,7 @@ func recvBlob(
 		return err
 	}
 
-	if streamErr := streamBlobChunks(env, s, writer, header.BlobId); streamErr != nil {
+	if streamErr := streamBlobInto(s, writer, header); streamErr != nil {
 		// Close to release the writer's resources; the partial blob is not
 		// committed because its digest will not match anything referenced.
 		_ = writer.Close()
@@ -459,42 +465,38 @@ func recvBlob(
 	return err
 }
 
-// streamBlobChunks copies blob frames into writer until the zero-length
-// terminator frame.
-func streamBlobChunks(
-	env env_ui.Env,
+// streamBlobInto copies the framed (and optionally zstd-compressed) blob body
+// into writer, then drains any trailing frames through the terminator so the
+// session stays aligned for the next frame.
+func streamBlobInto(
 	s *session,
 	writer mad_domain_interfaces.BlobWriter,
-	blobIdString string,
+	header control,
 ) (err error) {
-	for {
-		errors.ContextContinueOrPanic(env)
+	frameReader := &blobFrameReader{session: s}
 
-		kind, length, frameErr := readFrameHeader(s.reader)
-		if frameErr != nil {
-			err = errors.Wrapf(frameErr, "reading blob frame for %s", blobIdString)
-			return err
-		}
+	var source io.Reader = frameReader
 
-		if kind != frameKindBlob {
-			err = errors.Errorf(
-				"expected blob frame for %s, got kind %d",
-				blobIdString,
-				kind,
-			)
-			return err
-		}
-
-		if length == 0 {
-			// Terminator: the blob is complete.
-			return err
-		}
-
-		if _, err = io.CopyN(writer, s.reader, int64(length)); err != nil {
-			err = errors.Wrapf(err, "writing blob %s", blobIdString)
-			return err
-		}
+	if header.Compression == CompressionZstd {
+		decoder := zstd.NewReader(frameReader)
+		defer errors.DeferredCloser(&err, decoder)
+		source = decoder
 	}
+
+	if _, err = io.Copy(writer, source); err != nil {
+		err = errors.Wrapf(err, "writing blob %s", header.BlobId)
+		return err
+	}
+
+	// A zstd decoder can stop once its stream ends, before consuming the
+	// terminator frame; drain the remaining frames so the next read starts
+	// at the next message.
+	if _, err = io.Copy(io.Discard, frameReader); err != nil {
+		err = errors.Wrapf(err, "draining blob %s", header.BlobId)
+		return err
+	}
+
+	return err
 }
 
 // importObjects decodes the inventory_list payload and imports it through

--- a/go/internal/sierra/remote_proto/transfer.go
+++ b/go/internal/sierra/remote_proto/transfer.go
@@ -3,7 +3,6 @@ package remote_proto
 import (
 	"bytes"
 	"io"
-	"time"
 
 	"code.linenisgreat.com/dodder/go/internal/bravo/env_ui"
 	"code.linenisgreat.com/dodder/go/internal/bravo/ids"
@@ -13,7 +12,6 @@ import (
 	"code.linenisgreat.com/dodder/go/internal/papa/repo"
 	"code.linenisgreat.com/dodder/go/internal/romeo/local_working_copy"
 	"code.linenisgreat.com/dodder/go/lib/alfa/quiter"
-	"code.linenisgreat.com/dodder/go/lib/alfa/ui"
 	mad_blob_io "github.com/amarbel-llc/madder/go/pkgs/blob_io"
 	"github.com/amarbel-llc/madder/go/pkgs/blob_stores"
 	mad_domain_interfaces "github.com/amarbel-llc/madder/go/pkgs/domain_interfaces"
@@ -222,14 +220,9 @@ func sendOneBlob(
 
 	defer errors.DeferredCloser(&err, reader)
 
-	var data []byte
-
-	if data, err = io.ReadAll(reader); err != nil {
-		err = errors.Wrapf(err, "reading blob %s", key)
-		return err
-	}
-
-	if err = s.writeBlob(key, data); err != nil {
+	// Stream the blob straight from the store to the wire; writeBlob chunks
+	// it so nothing is buffered whole.
+	if err = s.writeBlob(key, reader); err != nil {
 		err = errors.Wrap(err)
 		return err
 	}
@@ -420,29 +413,15 @@ func negotiateHave(
 	return err
 }
 
-// recvBlob reads the blob frame announced by a blob_header and writes it to
-// the local store, verifying the content digest against the header.
+// recvBlob streams the blob announced by a blob_header into the local store —
+// a sequence of blob frames terminated by a zero-length frame — and verifies
+// the computed content digest against the header. Nothing is buffered whole.
 func recvBlob(
 	env env_ui.Env,
 	s *session,
 	blobStore blob_stores.BlobStoreInitialized,
 	header control,
 ) (err error) {
-	kind, length, frameErr := readFrameHeader(s.reader)
-	if frameErr != nil {
-		err = errors.Wrapf(frameErr, "reading blob frame for %s", header.BlobId)
-		return err
-	}
-
-	if kind != frameKindBlob {
-		err = errors.Errorf(
-			"expected blob frame after header for %s, got kind %d",
-			header.BlobId,
-			kind,
-		)
-		return err
-	}
-
 	var writer mad_domain_interfaces.BlobWriter
 
 	if writer, err = blobStore.MakeBlobWriter(nil); err != nil {
@@ -450,37 +429,72 @@ func recvBlob(
 		return err
 	}
 
-	var expected mad_domain_interfaces.MarklId
+	if streamErr := streamBlobChunks(env, s, writer, header.BlobId); streamErr != nil {
+		// Close to release the writer's resources; the partial blob is not
+		// committed because its digest will not match anything referenced.
+		_ = writer.Close()
+		err = errors.Wrap(streamErr)
+		return err
+	}
+
+	if err = writer.Close(); err != nil {
+		err = errors.Wrapf(err, "closing blob %s", header.BlobId)
+		return err
+	}
 
 	if header.BlobId != "" {
-		var expectedId markl.Id
+		var expected markl.Id
 
-		if err = expectedId.Set(header.BlobId); err != nil {
+		if err = expected.Set(header.BlobId); err != nil {
 			err = errors.Wrap(err)
 			return err
 		}
 
-		expected = &expectedId
-	}
-
-	copyResult := blob_stores.CopyReaderToWriter(
-		env,
-		writer,
-		io.LimitReader(s.reader, int64(length)),
-		expected,
-		nil,
-		func(time.Time) {
-			ui.Err().Printf("receiving blob %s...", header.BlobId)
-		},
-		3*time.Second,
-	)
-
-	if err = copyResult.GetError(); err != nil {
-		err = errors.Wrapf(err, "writing blob %s", header.BlobId)
-		return err
+		if err = markl.AssertEqual(&expected, writer.GetMarklId()); err != nil {
+			err = errors.Wrapf(err, "blob %s digest mismatch", header.BlobId)
+			return err
+		}
 	}
 
 	return err
+}
+
+// streamBlobChunks copies blob frames into writer until the zero-length
+// terminator frame.
+func streamBlobChunks(
+	env env_ui.Env,
+	s *session,
+	writer mad_domain_interfaces.BlobWriter,
+	blobIdString string,
+) (err error) {
+	for {
+		errors.ContextContinueOrPanic(env)
+
+		kind, length, frameErr := readFrameHeader(s.reader)
+		if frameErr != nil {
+			err = errors.Wrapf(frameErr, "reading blob frame for %s", blobIdString)
+			return err
+		}
+
+		if kind != frameKindBlob {
+			err = errors.Errorf(
+				"expected blob frame for %s, got kind %d",
+				blobIdString,
+				kind,
+			)
+			return err
+		}
+
+		if length == 0 {
+			// Terminator: the blob is complete.
+			return err
+		}
+
+		if _, err = io.CopyN(writer, s.reader, int64(length)); err != nil {
+			err = errors.Wrapf(err, "writing blob %s", blobIdString)
+			return err
+		}
+	}
 }
 
 // importObjects decodes the inventory_list payload and imports it through

--- a/go/internal/sierra/remote_proto/transfer.go
+++ b/go/internal/sierra/remote_proto/transfer.go
@@ -1,0 +1,398 @@
+package remote_proto
+
+import (
+	"bytes"
+	"io"
+	"time"
+
+	"code.linenisgreat.com/dodder/go/internal/bravo/env_ui"
+	"code.linenisgreat.com/dodder/go/internal/bravo/ids"
+	"code.linenisgreat.com/dodder/go/internal/foxtrot/sku"
+	"code.linenisgreat.com/dodder/go/internal/juliett/queries"
+	"code.linenisgreat.com/dodder/go/internal/oscar/store"
+	"code.linenisgreat.com/dodder/go/internal/papa/repo"
+	"code.linenisgreat.com/dodder/go/internal/romeo/local_working_copy"
+	"code.linenisgreat.com/dodder/go/lib/alfa/quiter"
+	"code.linenisgreat.com/dodder/go/lib/alfa/ui"
+	mad_blob_io "github.com/amarbel-llc/madder/go/pkgs/blob_io"
+	"github.com/amarbel-llc/madder/go/pkgs/blob_stores"
+	mad_domain_interfaces "github.com/amarbel-llc/madder/go/pkgs/domain_interfaces"
+	"github.com/amarbel-llc/madder/go/pkgs/markl"
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/errors"
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/interfaces"
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/pool"
+)
+
+// sendClosure is the sender half of a transfer (the server for fetch, the
+// client for push). It resolves the want's query against src, expands the
+// transitive closure with the type system's edge explorer, then streams the
+// closure to the peer: blobs first (so the receiver imports against blobs
+// already on disk), then the object batch, then a completion ack.
+func sendClosure(
+	env env_ui.Env,
+	s *session,
+	src repo.Repo,
+	envAdder interfaces.EnvVarsAdder,
+	want control,
+) (err error) {
+	var queryGroup *queries.Query
+
+	if queryGroup, err = src.MakeExternalQueryGroup(
+		nil,
+		sku.ExternalQueryOptions{},
+		want.Query,
+	); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	var list *sku.HeapTransacted
+
+	if list, err = src.MakeInventoryList(queryGroup); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	explorer := store.MakeEdgeExplorer(
+		src.GetObjectStore(),
+		src.GetBlobStore(),
+		envAdder,
+	)
+
+	var edges sku.Edges
+
+	if edges, err = expandEdges(list, src.GetObjectStore(), explorer); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	if len(edges.Skipped) > 0 {
+		err = errors.Errorf(
+			"edge traversal had %d failures: %s",
+			len(edges.Skipped),
+			edges.Skipped[0],
+		)
+		return err
+	}
+
+	if !want.ExcludeBlobs {
+		if err = sendBlobs(env, s, src.GetBlobStore(), list, edges); err != nil {
+			err = errors.Wrap(err)
+			return err
+		}
+	}
+
+	if err = sendObjects(env, s, src, list); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	if err = s.writeControl(TypeAck, control{Status: StatusComplete}); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	return err
+}
+
+// sendBlobs streams every blob in the closure: each object's own blob plus
+// every blob reference discovered by expand-edges, deduplicated. v1 sends
+// the whole closure rather than negotiating haves; the receiver's
+// content-addressed store deduplicates blobs it already holds.
+func sendBlobs(
+	env env_ui.Env,
+	s *session,
+	blobStore blob_stores.BlobStoreInitialized,
+	list *sku.HeapTransacted,
+	edges sku.Edges,
+) (err error) {
+	seen := make(map[string]struct{})
+
+	send := func(digest mad_domain_interfaces.MarklId) (err error) {
+		if digest == nil || digest.IsNull() {
+			return err
+		}
+
+		key := digest.String()
+
+		if _, ok := seen[key]; ok {
+			return err
+		}
+
+		seen[key] = struct{}{}
+
+		var reader mad_domain_interfaces.BlobReader
+
+		if reader, err = blobStore.MakeBlobReader(digest); err != nil {
+			// A blob that is referenced but absent locally is skipped
+			// rather than failing the whole transfer, matching
+			// CopyBlobIfNecessary's tolerance on the local pull path.
+			if mad_blob_io.IsErrBlobMissing(err) {
+				return nil
+			}
+
+			err = errors.Wrapf(err, "opening blob %s", key)
+			return err
+		}
+
+		defer errors.DeferredCloser(&err, reader)
+
+		var data []byte
+
+		if data, err = io.ReadAll(reader); err != nil {
+			err = errors.Wrapf(err, "reading blob %s", key)
+			return err
+		}
+
+		if err = s.writeBlob(key, data); err != nil {
+			err = errors.Wrap(err)
+			return err
+		}
+
+		return err
+	}
+
+	for object := range list.All() {
+		errors.ContextContinueOrPanic(env)
+
+		if err = send(object.GetBlobDigest()); err != nil {
+			err = errors.Wrap(err)
+			return err
+		}
+	}
+
+	for i := range edges.Blobs {
+		errors.ContextContinueOrPanic(env)
+
+		if err = send(&edges.Blobs[i]); err != nil {
+			err = errors.Wrap(err)
+			return err
+		}
+	}
+
+	return err
+}
+
+// sendObjects encodes the closure as one inventory_list hyphence stream and
+// writes it as a single objects frame. It uses the *typed* writer so the
+// stream carries its `! inventory_list-vN` metadata line, which the
+// receiver's AllDecodedObjectsFromStream reads to select the decoder (the
+// same typed-stream contract the HTTP backend's POST /inventory_lists uses).
+func sendObjects(
+	env env_ui.Env,
+	s *session,
+	src repo.Repo,
+	list *sku.HeapTransacted,
+) (err error) {
+	listType := ids.GetOrPanic(
+		src.GetImmutableConfigPublic().GetInventoryListTypeId(),
+	).TypeStruct
+
+	buffer := bytes.NewBuffer(nil)
+
+	bufferedWriter, repoolBufferedWriter := pool.GetBufferedWriter(buffer)
+	defer repoolBufferedWriter()
+
+	if _, err = src.GetInventoryListCoderCloset().WriteTypedBlobToWriter(
+		env,
+		listType,
+		quiter.MakeSeqErrorFromSeq(list.All()),
+		bufferedWriter,
+	); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	if err = bufferedWriter.Flush(); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	if err = s.writeObjects(buffer.Bytes()); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	return err
+}
+
+// receiveClosure is the receiver half of a transfer (the client for fetch,
+// the server for push). It reads frames until a completion ack: blob frames
+// are written to the local store (and digest-verified), the objects frame is
+// imported through the ordinary importer.
+func receiveClosure(
+	env env_ui.Env,
+	s *session,
+	dst *local_working_copy.Repo,
+	want control,
+	storeOptions sku.StoreOptions,
+) (err error) {
+	blobStore := dst.GetBlobStore()
+
+	importerOptions := repo.ImporterOptions{
+		CheckedOutPrinter:   dst.PrinterCheckedOutConflictsForRemoteTransfers(),
+		AllowMergeConflicts: want.AllowMergeConflicts,
+		BlobCopierDelegate: sku.MakeBlobCopierDelegate(
+			dst.GetEnv().GetUI(),
+			false,
+		),
+	}
+
+	for {
+		errors.ContextContinueOrPanic(env)
+
+		kind, length, frameErr := readFrameHeader(s.reader)
+		if frameErr != nil {
+			if errors.IsEOF(frameErr) {
+				err = errors.Errorf("stream closed before completion ack")
+				return err
+			}
+
+			err = errors.Wrap(frameErr)
+			return err
+		}
+
+		switch kind {
+		case frameKindControl:
+			var payload []byte
+
+			if payload, err = readFramePayload(s.reader, length); err != nil {
+				err = errors.Wrap(err)
+				return err
+			}
+
+			var typeString string
+			var msg control
+
+			if typeString, msg, err = decodeControl(payload); err != nil {
+				err = errors.Wrap(err)
+				return err
+			}
+
+			switch typeString {
+			case "!" + TypeBlobHeader:
+				if err = recvBlob(env, s, blobStore, msg); err != nil {
+					err = errors.Wrap(err)
+					return err
+				}
+
+			case "!" + TypeAck:
+				if msg.Status == StatusComplete {
+					return err
+				}
+
+			case "!" + TypeError:
+				err = errors.Errorf("remote error: %s", msg.Message)
+				return err
+
+			default:
+				err = errors.Errorf("unexpected control frame %q", typeString)
+				return err
+			}
+
+		case frameKindObjects:
+			var payload []byte
+
+			if payload, err = readFramePayload(s.reader, length); err != nil {
+				err = errors.Wrap(err)
+				return err
+			}
+
+			if err = importObjects(dst, payload, importerOptions, storeOptions); err != nil {
+				err = errors.Wrap(err)
+				return err
+			}
+
+		default:
+			err = errors.Errorf("unexpected frame kind %d", kind)
+			return err
+		}
+	}
+}
+
+// recvBlob reads the blob frame announced by a blob_header and writes it to
+// the local store, verifying the content digest against the header.
+func recvBlob(
+	env env_ui.Env,
+	s *session,
+	blobStore blob_stores.BlobStoreInitialized,
+	header control,
+) (err error) {
+	kind, length, frameErr := readFrameHeader(s.reader)
+	if frameErr != nil {
+		err = errors.Wrapf(frameErr, "reading blob frame for %s", header.BlobId)
+		return err
+	}
+
+	if kind != frameKindBlob {
+		err = errors.Errorf(
+			"expected blob frame after header for %s, got kind %d",
+			header.BlobId,
+			kind,
+		)
+		return err
+	}
+
+	var writer mad_domain_interfaces.BlobWriter
+
+	if writer, err = blobStore.MakeBlobWriter(nil); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	var expected mad_domain_interfaces.MarklId
+
+	if header.BlobId != "" {
+		var expectedId markl.Id
+
+		if err = expectedId.Set(header.BlobId); err != nil {
+			err = errors.Wrap(err)
+			return err
+		}
+
+		expected = &expectedId
+	}
+
+	copyResult := blob_stores.CopyReaderToWriter(
+		env,
+		writer,
+		io.LimitReader(s.reader, int64(length)),
+		expected,
+		nil,
+		func(time.Time) {
+			ui.Err().Printf("receiving blob %s...", header.BlobId)
+		},
+		3*time.Second,
+	)
+
+	if err = copyResult.GetError(); err != nil {
+		err = errors.Wrapf(err, "writing blob %s", header.BlobId)
+		return err
+	}
+
+	return err
+}
+
+// importObjects decodes the inventory_list payload and imports it through
+// the ordinary importer, the same path the HTTP server uses for a received
+// inventory list.
+func importObjects(
+	dst *local_working_copy.Repo,
+	payload []byte,
+	importerOptions repo.ImporterOptions,
+	storeOptions sku.StoreOptions,
+) (err error) {
+	importer := dst.MakeImporter(importerOptions, storeOptions)
+
+	seq := dst.GetInventoryListCoderCloset().AllDecodedObjectsFromStream(
+		bytes.NewReader(payload),
+		nil,
+	)
+
+	if err = dst.ImportSeq(seq, importer); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	return err
+}

--- a/go/internal/sierra/remote_proto/transport_websocket.go
+++ b/go/internal/sierra/remote_proto/transport_websocket.go
@@ -1,0 +1,148 @@
+package remote_proto
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+
+	"code.linenisgreat.com/dodder/go/lib/alfa/ui"
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/errors"
+	"github.com/coder/websocket"
+)
+
+// The websocket transport is the motivating addition of RFC 0004: it carries
+// the drtp session over a connection upgraded from an ordinary HTTP request,
+// so the protocol can traverse HTTP proxies and share a port with a web
+// frontend. websocket.NetConn adapts the upgraded connection to a net.Conn,
+// so the same session code runs unchanged over websockets, stdio, raw TCP,
+// and the in-memory net.Pipe used by the tests.
+
+// Serve accepts HTTP connections on listener and upgrades requests to
+// PathTransfer into drtp sessions. PathHealthz is served without an upgrade
+// for liveness probes, mirroring remote_http.
+func (server *Server) Serve(listener net.Listener) (err error) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc(PathHealthz, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		_, _ = io.WriteString(w, "ok\n")
+	})
+
+	mux.HandleFunc(PathTransfer, server.handleTransfer)
+
+	httpServer := &http.Server{Handler: mux}
+
+	go func() {
+		<-server.Repo.GetEnv().Done()
+		_ = httpServer.Close()
+	}()
+
+	if err = httpServer.Serve(listener); err != nil {
+		if errors.Is(err, http.ErrServerClosed) {
+			err = nil
+		} else {
+			err = errors.Wrap(err)
+			return err
+		}
+	}
+
+	return err
+}
+
+func (server *Server) handleTransfer(
+	responseWriter http.ResponseWriter,
+	request *http.Request,
+) {
+	conn, err := websocket.Accept(
+		responseWriter,
+		request,
+		// CLI clients do not send a browser Origin; skip the cross-origin
+		// check. Authentication is the per-session markl challenge, not the
+		// Origin header.
+		&websocket.AcceptOptions{InsecureSkipVerify: true},
+	)
+	if err != nil {
+		ui.Err().Printf("websocket upgrade failed: %s", err)
+		return
+	}
+
+	// Disable the default 32 KiB message read limit: a flushed objects or
+	// blob frame may be a single large message.
+	conn.SetReadLimit(-1)
+
+	netConn := websocket.NetConn(
+		request.Context(),
+		conn,
+		websocket.MessageBinary,
+	)
+
+	if serveErr := server.ServeConn(netConn); serveErr != nil {
+		ui.Err().Printf("drtp session failed: %s", serveErr)
+		_ = conn.Close(websocket.StatusInternalError, "transfer failed")
+		return
+	}
+
+	_ = conn.Close(websocket.StatusNormalClosure, "")
+}
+
+// ServeStdio runs a single drtp session over the process's stdin/stdout,
+// for the `dodder serve-proto -` (local and SSH) transports.
+func (server *Server) ServeStdio() (err error) {
+	if err = server.ServeConn(stdioReadWriteCloser{}); err != nil {
+		err = errors.Wrap(err)
+		return err
+	}
+
+	return err
+}
+
+// DialWebSocket upgrades an HTTP connection to urlString into a drtp byte
+// stream. ctx bounds the connection's lifetime and MUST outlive the
+// transfer.
+func DialWebSocket(
+	ctx context.Context,
+	urlString string,
+) (conn io.ReadWriteCloser, err error) {
+	wsConn, _, dialErr := websocket.Dial(ctx, urlString, nil)
+	if dialErr != nil {
+		err = errors.Wrapf(dialErr, "dialing websocket %q", urlString)
+		return conn, err
+	}
+
+	wsConn.SetReadLimit(-1)
+
+	conn = websocket.NetConn(ctx, wsConn, websocket.MessageBinary)
+
+	return conn, err
+}
+
+// WebSocketURL converts an http(s) base URL into the ws(s) PathTransfer URL
+// a client dials. A bare host (no scheme) defaults to ws://.
+func WebSocketURL(base string) string {
+	switch {
+	case strings.HasPrefix(base, "https://"):
+		base = "wss://" + strings.TrimPrefix(base, "https://")
+	case strings.HasPrefix(base, "http://"):
+		base = "ws://" + strings.TrimPrefix(base, "http://")
+	case strings.HasPrefix(base, "wss://"), strings.HasPrefix(base, "ws://"):
+		// already a websocket scheme
+	default:
+		base = "ws://" + base
+	}
+
+	base = strings.TrimRight(base, "/")
+
+	return base + PathTransfer
+}
+
+// stdioReadWriteCloser presents the process's stdin/stdout as one byte
+// stream for the stdio transport. Close is a no-op: the parent process owns
+// the descriptors.
+type stdioReadWriteCloser struct{}
+
+func (stdioReadWriteCloser) Read(p []byte) (int, error)  { return os.Stdin.Read(p) }
+func (stdioReadWriteCloser) Write(p []byte) (int, error) { return os.Stdout.Write(p) }
+func (stdioReadWriteCloser) Close() error                { return nil }

--- a/go/internal/tango/command_components_dodder/remote.go
+++ b/go/internal/tango/command_components_dodder/remote.go
@@ -1,6 +1,7 @@
 package command_components_dodder
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 
@@ -19,6 +20,7 @@ import (
 	"code.linenisgreat.com/dodder/go/internal/papa/repo"
 	"code.linenisgreat.com/dodder/go/internal/romeo/local_working_copy"
 	"code.linenisgreat.com/dodder/go/internal/sierra/remote_http"
+	"code.linenisgreat.com/dodder/go/internal/sierra/remote_proto"
 	"code.linenisgreat.com/dodder/go/lib/bravo/cli"
 	env_local "github.com/amarbel-llc/madder/go/pkgs/env_local"
 	"github.com/amarbel-llc/madder/go/pkgs/markl"
@@ -55,6 +57,61 @@ func (cmd *Remote) SetFlagDefinitions(
 
 func (cmd Remote) IsDirectTransfer() bool {
 	return cmd.DirectPath != ""
+}
+
+// IsWebSocketProtocol reports whether the remote should be reached over the
+// drtp websocket transport (sierra/remote_proto, RFC 0004) rather than the
+// legacy remote_http backend.
+func (cmd Remote) IsWebSocketProtocol() bool {
+	return cmd.RemoteConnectionType == remote_connection_types.TypeUrlWebsocket
+}
+
+// MakeProtoConnectionFromObject resolves a stored url remote object to a
+// drtp websocket connection and a client bound to local. Used by pull/push
+// when -remote-connection-type=url-websocket is set.
+func (cmd Remote) MakeProtoConnectionFromObject(
+	req command.Request,
+	local *local_working_copy.Repo,
+	object *sku.Transacted,
+) (conn io.ReadWriteCloser, client *remote_proto.Client) {
+	envRepo := cmd.MakeEnvRepo(req, false)
+	typedRepoBlobStore := typed_blob_store.MakeRepoStore(envRepo)
+
+	var blob repo_blobs.Blob
+
+	{
+		var err error
+
+		if blob, _, err = typedRepoBlobStore.ReadTypedBlob(
+			object.GetMetadata().GetType(),
+			object.GetBlobDigest(),
+		); err != nil {
+			req.Cancel(err)
+		}
+	}
+
+	uriBlob, ok := blob.(repo_blobs.BlobUri)
+	if !ok {
+		errors.ContextCancelWithErrorf(
+			req,
+			"the websocket protocol requires a url remote, got %T",
+			blob,
+		)
+	}
+
+	uri := uriBlob.GetUri()
+	url := uri.GetUrl()
+
+	var err error
+
+	if conn, err = remote_proto.DialWebSocket(
+		req,
+		remote_proto.WebSocketURL(url.String()),
+	); err != nil {
+		req.Cancel(err)
+	}
+
+	return conn, remote_proto.MakeClient(local)
 }
 
 func (cmd *Remote) ResolveImplicitDirectPath(
@@ -164,7 +221,14 @@ func (cmd Remote) MakeRemoteAndObject(
 		remoteObject.GetMetadata().GetType(),
 	)
 
-	remote = cmd.MakeRemoteFromBlobAndSetPublicKey(req, local, blob)
+	// A websocket remote is registered Trust-On-First-Use: serve-proto
+	// speaks drtp over /drtp, not the remote_http REST surface, so there is
+	// no /config-immutable to fetch the public key from at add time. The
+	// server attests per-session during the transfer instead. remote-add
+	// ignores the returned remote, so leaving it nil here is safe.
+	if !cmd.IsWebSocketProtocol() {
+		remote = cmd.MakeRemoteFromBlobAndSetPublicKey(req, local, blob)
+	}
 
 	var blobId mad_domain_interfaces.MarklId
 

--- a/go/internal/uniform/commands_dodder/clone.go
+++ b/go/internal/uniform/commands_dodder/clone.go
@@ -5,6 +5,7 @@ import (
 	"code.linenisgreat.com/dodder/go/internal/bravo/ids"
 	"code.linenisgreat.com/dodder/go/internal/delta/command"
 	"code.linenisgreat.com/dodder/go/internal/foxtrot/env_repo"
+	"code.linenisgreat.com/dodder/go/internal/foxtrot/sku"
 	"code.linenisgreat.com/dodder/go/internal/juliett/queries"
 	"code.linenisgreat.com/dodder/go/internal/papa/repo"
 	"code.linenisgreat.com/dodder/go/internal/tango/command_components_dodder"
@@ -64,9 +65,17 @@ func (cmd Clone) Run(req command.Request) {
 	local := cmd.OnTheFirstDay(req, req.PopArg("new repo id"))
 
 	var remote repo.Repo
+	var remoteObject *sku.Transacted
+	useProto := false
 
 	if cmd.IsDirectTransfer() {
 		remote = cmd.MakeDirectRemoteFromPath(req, local)
+	} else if cmd.IsWebSocketProtocol() {
+		// MakeRemoteAndObject builds the remote object (carrying the url)
+		// without connecting for a websocket remote, so we get the object
+		// to dial and skip the remote_http client entirely.
+		_, remoteObject = cmd.MakeRemoteAndObject(req, local)
+		useProto = true
 	} else {
 		// TODO offer option to persist remote object, if supported
 		remote, _ = cmd.MakeRemoteAndObject(req, local)
@@ -85,7 +94,17 @@ func (cmd Clone) Run(req command.Request) {
 		req.PopArgs(),
 	)
 
-	if err := local.PullQueryGroupFromRemote(
+	if useProto {
+		conn, client := cmd.MakeProtoConnectionFromObject(req, local, remoteObject)
+
+		if err := client.Fetch(
+			conn,
+			queryGroup.String(),
+			cmd.WithPrintCopies(true),
+		); err != nil {
+			req.Cancel(err)
+		}
+	} else if err := local.PullQueryGroupFromRemote(
 		remote,
 		queryGroup,
 		cmd.WithPrintCopies(true),

--- a/go/internal/uniform/commands_dodder/pull.go
+++ b/go/internal/uniform/commands_dodder/pull.go
@@ -54,14 +54,14 @@ func (cmd Pull) Run(req command.Request) {
 	cmd.ResolveImplicitDirectPath(localWorkingCopy)
 
 	var remote repo.Repo
+	var object *sku.Transacted
+	useProto := false
 
 	if cmd.IsHomeRepoParent() {
 		remote = cmd.MakeHomeRepoRemote(req)
 	} else if cmd.IsDirectTransfer() {
 		remote = cmd.MakeDirectRemoteFromPath(req, localWorkingCopy)
 	} else {
-		var object *sku.Transacted
-
 		{
 			var err error
 
@@ -72,7 +72,11 @@ func (cmd Pull) Run(req command.Request) {
 			}
 		}
 
-		remote = cmd.MakeRemote(req, localWorkingCopy, object)
+		if cmd.IsWebSocketProtocol() {
+			useProto = true
+		} else {
+			remote = cmd.MakeRemote(req, localWorkingCopy, object)
+		}
 	}
 
 	qg := cmd.MakeQueryIncludingWorkspace(
@@ -88,7 +92,21 @@ func (cmd Pull) Run(req command.Request) {
 		req.PopArgs(),
 	)
 
-	if err := localWorkingCopy.PullQueryGroupFromRemote(
+	if useProto {
+		conn, client := cmd.MakeProtoConnectionFromObject(
+			req,
+			localWorkingCopy,
+			object,
+		)
+
+		if err := client.Fetch(
+			conn,
+			qg.String(),
+			cmd.WithPrintCopies(true),
+		); err != nil {
+			localWorkingCopy.Cancel(err)
+		}
+	} else if err := localWorkingCopy.PullQueryGroupFromRemote(
 		remote,
 		qg,
 		cmd.WithPrintCopies(true),

--- a/go/internal/uniform/commands_dodder/push.go
+++ b/go/internal/uniform/commands_dodder/push.go
@@ -54,14 +54,14 @@ func (cmd Push) Run(req command.Request) {
 	cmd.ResolveImplicitDirectPath(local)
 
 	var remote repo.Repo
+	var remoteObject *sku.Transacted
+	useProto := false
 
 	if cmd.IsHomeRepoParent() {
 		remote = cmd.MakeHomeRepoRemote(req)
 	} else if cmd.IsDirectTransfer() {
 		remote = cmd.MakeDirectRemoteFromPath(req, local)
 	} else {
-		var remoteObject *sku.Transacted
-
 		{
 			var err error
 
@@ -72,7 +72,11 @@ func (cmd Push) Run(req command.Request) {
 			}
 		}
 
-		remote = cmd.MakeRemote(req, local, remoteObject)
+		if cmd.IsWebSocketProtocol() {
+			useProto = true
+		} else {
+			remote = cmd.MakeRemote(req, local, remoteObject)
+		}
 	}
 
 	queryGroup := cmd.MakeQueryIncludingWorkspace(
@@ -88,7 +92,21 @@ func (cmd Push) Run(req command.Request) {
 		req.PopArgs(),
 	)
 
-	if err := remote.PullQueryGroupFromRemote(
+	if useProto {
+		conn, client := cmd.MakeProtoConnectionFromObject(
+			req,
+			local,
+			remoteObject,
+		)
+
+		if err := client.Push(
+			conn,
+			queryGroup.String(),
+			cmd.WithPrintCopies(true),
+		); err != nil {
+			local.Cancel(err)
+		}
+	} else if err := remote.PullQueryGroupFromRemote(
 		local,
 		queryGroup,
 		cmd.WithPrintCopies(true),

--- a/go/internal/uniform/commands_dodder/serve_proto.go
+++ b/go/internal/uniform/commands_dodder/serve_proto.go
@@ -1,0 +1,181 @@
+package commands_dodder
+
+import (
+	"fmt"
+	"net"
+	"os"
+
+	"code.linenisgreat.com/dodder/go/internal/bravo/env_ui"
+	"code.linenisgreat.com/dodder/go/internal/delta/command"
+	"code.linenisgreat.com/dodder/go/internal/echo/command_components"
+	"code.linenisgreat.com/dodder/go/internal/sierra/remote_proto"
+	"code.linenisgreat.com/dodder/go/internal/tango/command_components_dodder"
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/errors"
+	"github.com/amarbel-llc/purse-first/libs/dewey/pkgs/interfaces"
+)
+
+// ProtoHandshakeProtocolName is advertised in field 5 of the handshake
+// line so harnesses can distinguish a drtp server from the legacy
+// remote_http one. The line shape is identical to `serve -handshake`, so
+// the same port-discovery harness reads either.
+const ProtoHandshakeProtocolName = "dodder-drtp-v1"
+
+// ProtoHandshakeProtocolVersion is field 1 of the handshake line.
+const ProtoHandshakeProtocolVersion = 1
+
+func init() {
+	utility.AddCmd("serve-proto", &ServeProto{})
+}
+
+// ServeProto serves the drtp remote transfer protocol
+// (sierra/remote_proto, RFC 0004): a session protocol that streams a
+// sender-computed expand-edges closure, optionally over a websocket
+// upgraded from HTTP. It coexists with the legacy `serve` (remote_http)
+// command.
+type ServeProto struct {
+	command_components.Env
+	command_components_dodder.EnvRepo
+	command_components_dodder.LocalWorkingCopy
+
+	// Public serves fetches without requiring client attestation, mirroring
+	// `serve -public`. A push always requires attestation.
+	Public bool
+
+	// Handshake forces tcp + ephemeral port and prints a single
+	// pipe-delimited handshake line on stdout after binding, mirroring
+	// `serve -handshake`, so harnesses can discover the OS-assigned port.
+	Handshake bool
+}
+
+var _ interfaces.CommandComponentWriter = (*ServeProto)(nil)
+
+func (cmd ServeProto) GetDescription() command.Description {
+	return command.Description{
+		Short: "serve the drtp remote transfer protocol (websocket-capable)",
+	}
+}
+
+func (cmd *ServeProto) GetArgs() []command.ArgGroup {
+	return []command.ArgGroup{{
+		Args: []command.Arg{
+			{
+				Name:        "network",
+				Description: "network type (tcp, unix, or - for stdio)",
+			},
+			{
+				Name:        "address",
+				Description: "listen address (e.g. :8080)",
+			},
+		},
+	}}
+}
+
+func (cmd *ServeProto) SetFlagDefinitions(
+	flagSet interfaces.CLIFlagDefinitions,
+) {
+	cmd.LocalWorkingCopy.SetFlagDefinitions(flagSet)
+
+	flagSet.BoolVar(
+		&cmd.Public,
+		"public",
+		false,
+		"serve fetches without requiring client attestation",
+	)
+
+	flagSet.BoolVar(
+		&cmd.Handshake,
+		"handshake",
+		false,
+		"emit a handshake line on stdout after binding (forces tcp + ephemeral port)",
+	)
+}
+
+func (cmd ServeProto) Run(req command.Request) {
+	args := req.PopArgs()
+	errors.ContextSetCancelOnSIGHUP(req)
+
+	envLocal := cmd.MakeEnvWithOptions(
+		req,
+		env_ui.Options{
+			UIFileIsStderr: true,
+			IgnoreTtyState: true,
+		},
+	)
+
+	repo := cmd.MakeLocalWorkingCopyFromEnvLocal(envLocal)
+
+	server := remote_proto.Server{
+		EnvLocal: envLocal,
+		Repo:     repo,
+		Public:   cmd.Public,
+	}
+
+	var network, address string
+
+	switch len(args) {
+	case 0:
+		network = "tcp"
+		address = ":0"
+
+	case 1:
+		network = args[0]
+
+	default:
+		network = args[0]
+		address = args[1]
+	}
+
+	if cmd.Handshake {
+		network = "tcp"
+		address = "127.0.0.1:0"
+	}
+
+	if network == "-" {
+		if err := server.ServeStdio(); err != nil {
+			envLocal.Cancel(err)
+		}
+
+		return
+	}
+
+	var listener net.Listener
+
+	{
+		var err error
+
+		if listener, err = net.Listen(network, address); err != nil {
+			envLocal.Cancel(err)
+		}
+
+		defer errors.ContextMustClose(envLocal, listener)
+	}
+
+	if cmd.Handshake {
+		tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+		if !ok {
+			envLocal.Cancel(
+				errors.Errorf(
+					"-handshake requires tcp listener, got: %T",
+					listener.Addr(),
+				),
+			)
+		}
+
+		// Write directly to os.Stdout so the handshake is a deterministic
+		// process-level protocol output a harness can read from a pipe.
+		fmt.Fprintf(
+			os.Stdout,
+			"%d|1|tcp|127.0.0.1:%d|%s\n",
+			ProtoHandshakeProtocolVersion,
+			tcpAddr.Port,
+			ProtoHandshakeProtocolName,
+		)
+		_ = os.Stdout.Sync()
+	} else if addr, ok := listener.Addr().(*net.TCPAddr); ok {
+		envLocal.GetUI().Printf("serving drtp on port: %d", addr.Port)
+	}
+
+	if err := server.Serve(listener); err != nil {
+		envLocal.Cancel(err)
+	}
+}

--- a/zz-tests_bats/current_version/complete.bats
+++ b/zz-tests_bats/current_version/complete.bats
@@ -153,6 +153,7 @@ function complete_subcmd { # @test
 		^revert[[:space:]]+revert objects to their stored state$
 		^save[[:space:]]+commit workspace changes to the store$
 		^serve[[:space:]]+start the HTTP server$
+		^serve-proto[[:space:]]+serve the drtp remote transfer protocol \(websocket-capable\)$
 		^show[[:space:]]+display objects from the store$
 		^status[[:space:]]+show workspace object state$
 		^update[[:space:]]+update type lock signatures$

--- a/zz-tests_bats/current_version/serve_proto.bats
+++ b/zz-tests_bats/current_version/serve_proto.bats
@@ -1,0 +1,183 @@
+#! /usr/bin/env bats
+
+setup() {
+  load "$(dirname "$BATS_TEST_FILE")/../lib/common.bash"
+  export output
+
+  # Each repo gets its own XDG home so the transfer genuinely moves
+  # objects and blobs over the wire rather than sharing a store.
+  export them_home="$BATS_TEST_TMPDIR/them-home"
+  export us_home="$BATS_TEST_TMPDIR/us-home"
+}
+
+teardown() {
+  stop_proto_server
+  chflags_nouchg
+}
+
+# bats file_tags=serve,user_story:pull,user_story:push,user_story:remote
+
+# start_proto_server launches `dodder serve-proto -handshake` as a coproc,
+# reads the OS-assigned port from the handshake line, and exports
+# server_addr. Mirrors start_server (common.bash) but drives the drtp
+# (sierra/remote_proto) backend instead of remote_http.
+function start_proto_server {
+  local dir="$1"
+  shift || true
+  local serve_args=("$@")
+
+  coproc proto_server {
+    export DODDER_XDG_UTILITY_OVERRIDE="$them_home"
+    export MADDER_XDG_UTILITY_OVERRIDE="$them_home"
+    if [[ -n $dir ]]; then
+      cd "$dir" || exit 1
+    fi
+    # shellcheck disable=SC2068
+    "$DODDER_BIN" serve-proto ${cmd_dodder_def[@]} -handshake ${serve_args[@]}
+  }
+
+  local line
+  if ! IFS= read -r -t 5 -u "${proto_server[0]}" line; then
+    fail <<-EOM
+			no handshake from dodder serve-proto within 5s.
+			server pid: ${proto_server_PID:-unknown}
+		EOM
+  fi
+
+  # 1|1|tcp|127.0.0.1:PORT|dodder-drtp-v1
+  local _core _app _net addr _proto
+  IFS='|' read -r _core _app _net addr _proto <<<"$line"
+
+  if [[ -z $addr ]]; then
+    fail <<-EOM
+			could not parse handshake line from dodder serve-proto.
+			line: $line
+		EOM
+  fi
+
+  # shellcheck disable=SC2154
+  export server_addr="$addr"
+}
+
+function stop_proto_server {
+  if [[ -n ${proto_server_PID:-} ]]; then
+    kill "$proto_server_PID" 2>/dev/null || true
+    wait "$proto_server_PID" 2>/dev/null || true
+    unset proto_server_PID
+  fi
+  unset server_addr
+}
+
+function bootstrap_them {
+  export DODDER_XDG_UTILITY_OVERRIDE="$them_home"
+  export MADDER_XDG_UTILITY_OVERRIDE="$them_home"
+
+  mkdir -p them
+  (
+    pushd them || exit 1
+    run_dodder_init -repo_id . "test-repo-id-them"
+
+    run_dodder new -edit=false - <<-EOM
+			---
+			# wow
+			- tag
+			! md
+			---
+
+			body
+		EOM
+
+    assert_success
+    assert_output - <<-EOM
+			[one/uno @blake2b256-gu738nunyrnsqukgqkuaau9zslu0fhwg4dgs9ltuyvnlp42wal8sdpn2hc !md "wow" tag]
+		EOM
+  )
+}
+
+# pull_over_websocket exercises the drtp websocket transport end to end:
+# serve-proto in `them`, then a fetch from a separate `us` repo over
+# ws://. The server runs -public so the fetch needs no client attestation,
+# but the client still verifies the server's per-session attestation.
+function pull_over_websocket { # @test
+  bootstrap_them
+  start_proto_server them -public
+
+  export DODDER_XDG_UTILITY_OVERRIDE="$us_home"
+  export MADDER_XDG_UTILITY_OVERRIDE="$us_home"
+
+  mkdir -p us
+  pushd us || exit 1
+
+  run_dodder_init -repo_id . "test-repo-id-us"
+
+  run_dodder remote-add \
+    -remote-connection-type url-websocket \
+    toml-repo-uri-v0 \
+    "http://${server_addr}" \
+    them-ws
+
+  assert_success
+
+  run_dodder pull \
+    -remote-connection-type url-websocket \
+    /them-ws +zettel,typ,etikett
+
+  assert_success
+
+  # The transferred zettel is now present locally with its blob.
+  run_dodder show one/uno
+  assert_success
+  assert_output - <<-EOM
+		[one/uno @blake2b256-gu738nunyrnsqukgqkuaau9zslu0fhwg4dgs9ltuyvnlp42wal8sdpn2hc !md "wow" tag]
+	EOM
+}
+
+# push_over_websocket exercises the inverse direction with mandatory client
+# attestation (the server is NOT -public): a zettel created in `us` is
+# pushed to `them` over ws://.
+function push_over_websocket { # @test
+  export DODDER_XDG_UTILITY_OVERRIDE="$them_home"
+  export MADDER_XDG_UTILITY_OVERRIDE="$them_home"
+
+  mkdir -p them
+  (
+    pushd them || exit 1
+    run_dodder_init -repo_id . "test-repo-id-them"
+  )
+
+  start_proto_server them
+
+  export DODDER_XDG_UTILITY_OVERRIDE="$us_home"
+  export MADDER_XDG_UTILITY_OVERRIDE="$us_home"
+
+  mkdir -p us
+  pushd us || exit 1
+
+  run_dodder_init -repo_id . "test-repo-id-us"
+
+  run_dodder new -edit=false - <<-EOM
+		---
+		# wow
+		- tag
+		! md
+		---
+
+		body
+	EOM
+
+  assert_success
+
+  run_dodder remote-add \
+    -remote-connection-type url-websocket \
+    toml-repo-uri-v0 \
+    "http://${server_addr}" \
+    them-ws
+
+  assert_success
+
+  run_dodder push \
+    -remote-connection-type url-websocket \
+    /them-ws +zettel,typ,etikett
+
+  assert_success
+}

--- a/zz-tests_bats/current_version/serve_proto.bats
+++ b/zz-tests_bats/current_version/serve_proto.bats
@@ -132,6 +132,38 @@ function pull_over_websocket { # @test
 	EOM
 }
 
+# clone_over_websocket exercises a genesis clone over the drtp websocket
+# transport: a fresh repo is created and populated from `them` in one shot.
+function clone_over_websocket { # @test
+  bootstrap_them
+  start_proto_server them -public
+
+  export DODDER_XDG_UTILITY_OVERRIDE="$us_home"
+  export MADDER_XDG_UTILITY_OVERRIDE="$us_home"
+
+  mkdir -p us
+  pushd us || exit 1
+
+  run_dodder clone \
+    -encryption none \
+    -yin <(cat_yin) \
+    -yang <(cat_yang) \
+    -repo_id . \
+    -remote-connection-type url-websocket \
+    test-repo-id-us \
+    toml-repo-uri-v0 \
+    "http://${server_addr}" \
+    +zettel,typ,etikett
+
+  assert_success
+
+  run_dodder show one/uno
+  assert_success
+  assert_output - <<-EOM
+		[one/uno @blake2b256-gu738nunyrnsqukgqkuaau9zslu0fhwg4dgs9ltuyvnlp42wal8sdpn2hc !md "wow" tag]
+	EOM
+}
+
 # push_over_websocket exercises the inverse direction with mandatory client
 # attestation (the server is NOT -public): a zettel created in `us` is
 # pushed to `them` over ws://.


### PR DESCRIPTION
## Summary

Introduces `sierra/remote_proto` (drtp), a session-based remote transfer protocol that **hard-forks** the implicit REST protocol of `sierra/remote_http` (kept unchanged; the two coexist). Specified in `docs/rfcs/0004-remote-transfer-protocol.md`.

Shaped after git fetch/push: one connection carries a whole transfer through a capability handshake, blob have-negotiation, and a single sender-computed object+blob stream. Every control and payload message is a **typed hyphence document**, so the wire format inherits hyphence type-string versioning and markl-id content addressing rather than a bespoke pack format; object batches are the exact `inventory_list` stream the store already encodes.

The sender computes the transfer's transitive closure up front with the type system's **expand-edges** traversal, so a fetch delivers a complete, self-consistent object graph in one pass instead of the reactive missing-blob retry loop of the HTTP backend.

The session runs over any byte stream; the motivating transport is a **websocket** upgraded from HTTP (`coder/websocket` + `websocket.NetConn`), used when both peers support it. Per-session markl challenge/response replaces the per-request handshake.

## What's implemented

- **Protocol core** — length-prefixed frames; typed-hyphence control messages (JSON body); per-session mutual markl challenge/response (waivable for public fetches).
- **Expand-edges closure** — sender computes the full object+blob closure once (fork of `local_working_copy.expandEdges` over `store.MakeEdgeExplorer`).
- **WebSocket transport** — `serve-proto` serves `/drtp` upgrades + `/healthz`; client dials `ws(s)://…/drtp`. Same session code also runs over stdio/TCP/`net.Pipe`.
- **CLI** — `serve-proto` (tcp/unix/stdio, `-public`, `-handshake`); `remote_connection_types.TypeUrlWebsocket` (`url-websocket`); `pull` / `push` / `clone` dispatch to the drtp client under `-remote-connection-type=url-websocket`; `remote-add` registers a websocket url remote Trust-On-First-Use (no connect at add time).
- **Blob have-negotiation** — sender sends `drtp-manifest-v1` (closure blobs it holds), receiver replies `drtp-have-v1` (subset it already has), sender streams only the rest. A re-pull into a populated repo moves only new blobs.
- **Exclusive blob streaming** — blobs stream as chunked BLOB frames terminated by a zero-length frame; neither side buffers a blob whole. Digest verified after the terminator.
- **Negotiated zstd compression** — each peer advertises `compression` in capabilities; the sender compresses a blob's chunk stream (`DataDog/zstd`) only when the peer also supports it. Digest is verified over the **decompressed** bytes, so compression is transparent to content addressing.

## Verification

- `go build ./...`, `go vet`, and `remote_proto` unit tests pass: control/frame round-trips, markl auth handshake over `net.Pipe`, a full handshake over a real websocket (`httptest`), multi-chunk + empty-blob framing, and a zstd round-trip.
- End-to-end against the built binary: **pull, push, clone, re-pull (blob-skip), large (~500 KiB) multi-chunk blob, and zstd-compressed** transfer — each with a matching content-addressed digest on the receiving side.
- `go mod tidy` only flipped `coder/websocket` and `DataDog/zstd` indirect→direct; both already in `gomod2nix.toml`, so the module set (and the nix build) is unchanged. No store-version bump, so no fixtures to regenerate.

## Not verified in this environment (needs the nix toolchain)

- The nix-routed `just test` / bats lane was **not** run here (no `nix`/`just`/`bats` in the dev container). `zz-tests_bats/current_version/serve_proto.bats` (pull/push/clone over websocket) is written to convention and mirrors the validated binary flow, and `complete.bats` lists `serve-proto`, but both need a run in the nix lane.
- The repool static analyzer (`just check-go-repool`) was not run; pool usage mirrors existing patterns (`//repool:suppress` in the edges fork).

## Deferred / out of scope (follow-ups)

- **Object-stream compression & chunking** — the `inventory_list` objects frame is always sent raw and buffered in memory (64 MiB control-frame cap). Large repos and compressing the object stream are future work.
- **Object-level have-negotiation** — only *blobs* are negotiated; objects are always streamed and rely on the importer's idempotent commit. Skipping already-current objects (git-style ref negotiation) is deferred.
- **Configurable chunk size / compression level** — chunk size (64 KiB) and zstd level are hardcoded; no capability/flag to tune them. Only `zstd` and `none` are defined.
- **Delta encoding** — whole objects and whole blobs only (deduplicated by content address); git-style deltas are out of scope.
- **One transfer per session** — no frame multiplexing / concurrent fetch+push in a session.
- **Capability-driven auto-upgrade** — a stored plain `url` remote does not auto-probe `/drtp`; the websocket transport must be selected explicitly via `url-websocket`. Auto-upgrade-with-fallback is deferred.
- **`serve-proto` serves only `/drtp` + `/healthz`**, not the `remote_http` REST surface — hence `remote-add` is TOFU (cannot fetch `/config-immutable` over HTTP from a drtp server). Bridging the two, or carrying config in the capabilities frame for `remote-add`, is a follow-up.
- **Transport confidentiality** — the protocol does not encrypt payloads; `wss://`/TLS is the transport's responsibility (TLS wiring for `serve-proto` not added).

## Files

- RFC: `docs/rfcs/0004-remote-transfer-protocol.md`
- Package: `go/internal/sierra/remote_proto/` (+ `CLAUDE.md`, unit tests)
- CLI: `serve_proto.go`, `pull.go`, `push.go`, `clone.go`, `remote.go`, `remote_connection_types`
- Tests: `zz-tests_bats/current_version/serve_proto.bats`, `complete.bats`

https://claude.ai/code/session_01QvMCrcTbqbmCNg1kmFFtVn