### PR TITLE
Wire tommy as conformist (treelint) TOML formatter + codegen linter

### DIFF
--- a/go/default.nix
+++ b/go/default.nix
@@ -262,6 +262,47 @@ let
   # gofumpt/gotools are the same igloo `pkgs` builds the dev-shell carries,
   # so the Go output matches the dev-loop formatter. null on the non-flake
   # `import ./go/default.nix` path (treelint absent).
+  # tommy codegen as a conformist linter driver. Walks the tree for
+  # `//go:generate tommy generate` directives and runs `tommy generate` per file
+  # (REPAIR mode; the treelint.toml CHECK command is a no-op `true`). Resolves
+  # tommy + go from the AMBIENT PATH and skips (exit 0) when either is missing,
+  # so it is a safe no-op where the toolchain is absent. Regenerates the
+  # *_tommy.go companions so they land in the `conformist --commit` chore;
+  # `just build-go-generate` remains the NATO-ordered regen path.
+  tommyCodegen = pkgs.writeShellApplication {
+    name = "conformist-tommy-codegen";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.findutils
+      pkgs.gnugrep
+    ];
+    text = ''
+      mode="repair"
+      if [ "''${1:-}" = "--check" ]; then
+        mode="check"
+      fi
+      if ! command -v tommy >/dev/null 2>&1; then
+        echo "tommy-codegen: tommy not on PATH; skipping" >&2
+        exit 0
+      fi
+      if ! command -v go >/dev/null 2>&1; then
+        echo "tommy-codegen: go not on PATH; skipping" >&2
+        exit 0
+      fi
+      status=0
+      while IFS= read -r f; do
+        dir=$(dirname "$f")
+        base=$(basename "$f")
+        if [ "$mode" = "check" ]; then
+          ( cd "$dir" || exit 1; GOFILE="$base" tommy generate --check; ) || status=1
+        else
+          ( cd "$dir" || exit 1; GOFILE="$base" tommy generate; ) || status=1
+        fi
+      done < <(grep -rIl --include='*.go' 'go:generate tommy generate' . 2>/dev/null | grep -v '/result' || true)
+      exit "$status"
+    '';
+  };
+
   treelint-fmt =
     if treelint == null then
       null
@@ -275,6 +316,13 @@ let
           pkgs.nixfmt
           pkgs.shfmt
           pkgs.shellcheck
+          # tommy (TOML formatter, [formatter.tommy]) + go + the codegen driver
+          # ([linter.tommy-codegen]), so the wrapper resolves the formatter and
+          # the codegen repair regen. go is needed by `tommy generate`'s
+          # go/packages analysis in repair mode.
+          tommy.packages.${system}.default
+          pkgs.go_1_26
+          tommyCodegen
         ];
         text = ''exec conformist "$@"'';
       };

--- a/go/default.nix
+++ b/go/default.nix
@@ -262,46 +262,13 @@ let
   # gofumpt/gotools are the same igloo `pkgs` builds the dev-shell carries,
   # so the Go output matches the dev-loop formatter. null on the non-flake
   # `import ./go/default.nix` path (treelint absent).
-  # tommy codegen as a conformist linter driver. Walks the tree for
-  # `//go:generate tommy generate` directives and runs `tommy generate` per file
-  # (REPAIR mode; the treelint.toml CHECK command is a no-op `true`). Resolves
-  # tommy + go from the AMBIENT PATH and skips (exit 0) when either is missing,
-  # so it is a safe no-op where the toolchain is absent. Regenerates the
-  # *_tommy.go companions so they land in the `conformist --commit` chore;
-  # `just build-go-generate` remains the NATO-ordered regen path.
-  tommyCodegen = pkgs.writeShellApplication {
-    name = "conformist-tommy-codegen";
-    runtimeInputs = [
-      pkgs.coreutils
-      pkgs.findutils
-      pkgs.gnugrep
-    ];
-    text = ''
-      mode="repair"
-      if [ "''${1:-}" = "--check" ]; then
-        mode="check"
-      fi
-      if ! command -v tommy >/dev/null 2>&1; then
-        echo "tommy-codegen: tommy not on PATH; skipping" >&2
-        exit 0
-      fi
-      if ! command -v go >/dev/null 2>&1; then
-        echo "tommy-codegen: go not on PATH; skipping" >&2
-        exit 0
-      fi
-      status=0
-      while IFS= read -r f; do
-        dir=$(dirname "$f")
-        base=$(basename "$f")
-        if [ "$mode" = "check" ]; then
-          ( cd "$dir" || exit 1; GOFILE="$base" tommy generate --check; ) || status=1
-        else
-          ( cd "$dir" || exit 1; GOFILE="$base" tommy generate; ) || status=1
-        fi
-      done < <(grep -rIl --include='*.go' 'go:generate tommy generate' . 2>/dev/null | grep -v '/result' || true)
-      exit "$status"
-    '';
-  };
+  # tommy's conformist codegen linter driver ([linter.tommy-codegen]), owned by
+  # the tommy flake so the pinned tommy input resolves which tommy backs it (no
+  # per-repo driver duplication). It bakes that tommy in and skips when go is
+  # absent. Regenerates the *_tommy.go companions so they land in the
+  # `conformist --commit` chore; `just build-go-generate` remains the
+  # NATO-ordered regen path.
+  tommyCodegen = tommy.packages.${system}.conformist-tommy-codegen;
 
   treelint-fmt =
     if treelint == null then

--- a/treelint.toml
+++ b/treelint.toml
@@ -53,6 +53,13 @@ command = "shfmt"
 options = ["-w", "-i", "2", "-s", "-ci"]
 includes = ["*.sh", "*.bash"]
 
+# TOML via tommy's CST-preserving formatter (`tommy fmt`). treelint.toml itself
+# is excluded above (intentional layout).
+[formatter.tommy]
+command = "tommy"
+options = ["fmt"]
+includes = ["*.toml"]
+
 # Linter: shellcheck runs read-only in `treelint check` (no repair-command, so
 # it is a no-op in repair mode). Catches shell bugs the formatters miss.
 [linter.shellcheck]
@@ -61,3 +68,19 @@ includes = ["*.sh", "*.bash"]
 # go/vimdiff.bash is the vendored upstream git-vimdiff mergetool test harness;
 # it carries ~40 shellcheck findings we don't own. shfmt still formats it.
 excludes = ["go/vimdiff.bash"]
+
+# tommy codegen as a REPAIR linter: `treelint` / `conformist --commit` runs
+# `tommy generate` for every `//go:generate tommy generate` source file, so the
+# regenerated *_tommy.go companions land in the auto-fix chore. The driver
+# self-gates on tommy + go (present on the treelint-fmt wrapper PATH), so it is a
+# no-op where the toolchain is absent. The CHECK command is a deliberate no-op
+# (`true`) so `treelint check` never reports false codegen drift — `tommy
+# generate --check` compares against tommy's raw render, which differs from the
+# committed file once it is re-run through gofumpt (see `just build-go-generate`
+# / `codemod-go-fmt`); true staleness stays gated by that recipe.
+# passes-files=false: the driver walks the tree for the directive itself.
+[linter.tommy-codegen]
+command = "true"
+repair-command = "conformist-tommy-codegen"
+includes = ["*.go", "**/*.go"]
+passes-files = false


### PR DESCRIPTION
- `treelint.toml`: add `[formatter.tommy]` (`tommy fmt` over `*.toml`) and `[linter.tommy-codegen]`. The linter's **repair** regenerates the `*_tommy.go` companions via `tommy generate` so they land in the `conformist --commit` chore; the **check is a no-op `true`** so `treelint check` never reports false codegen drift (true staleness stays gated by `just build-go-generate`).
- `go/default.nix`: add tommy + go to the `treelint-fmt` wrapper (so the formatter and codegen repair resolve), and source the codegen driver from the tommy flake (`tommy.packages.<system>.conformist-tommy-codegen`) rather than an inline script — so the pinned tommy input resolves which tommy backs it.

Depends on amarbel-llc/tommy#136. Not validated with `nix` in the authoring environment.

https://claude.ai/code/session_01HWabFkHATxynhaY8LB4wF9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HWabFkHATxynhaY8LB4wF9)_